### PR TITLE
Add appNamespace support

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -14,7 +14,7 @@ import (
 // NewCR returns new application CR.
 //
 // AppCatalog is the name of the app catalog where the app stored.
-func NewCR(name, appName, appVersion, appCatalog string) *applicationv1alpha1.App {
+func NewCR(name, appName, appNamespace, appVersion, appCatalog string) *applicationv1alpha1.App {
 	appCR := &applicationv1alpha1.App{
 		TypeMeta: applicationv1alpha1.NewAppTypeMeta(),
 		ObjectMeta: metav1.ObjectMeta{
@@ -33,7 +33,7 @@ func NewCR(name, appName, appVersion, appCatalog string) *applicationv1alpha1.Ap
 				InCluster: true,
 			},
 			Name:      appName,
-			Namespace: "giantswarm",
+			Namespace: appNamespace,
 			Version:   appVersion,
 		},
 	}


### PR DESCRIPTION
So that we can configure namespace, where the chart should be installed.

E.g. I'm moving cert-manager into app collection and we install it into kube-system namespace. For monitoring apps it would be monitoring namespace