### PR TITLE
Set version label value to 0.0.0 for use in opsctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add version label value and remove hardcoding.
+- Set version label value to 0.0.0 so control plane app CRs are reconciled by
+  app-operator-unique. 
 
 ## [0.2.1] - 2020-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
+
+- Add version label value and remove hardcoding.
 
 ## [0.2.1] - 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/app.svg?style=shield)](https://circleci.com/gh/giantswarm/app)
+[![GoDoc](https://godoc.org/github.com/giantswarm/app?status.svg)](http://godoc.org/github.com/giantswarm/app) [![CircleCI](https://circleci.com/gh/giantswarm/app.svg?style=shield)](https://circleci.com/gh/giantswarm/app)
 
 # app
 
-Package app provides helper functions to handle [App CRs](https://github.com/giantswarm/apiextensions/tree/master/pkg/apis/application/v1alpha1) from apiextensions.
+Package app provides helper functions to handle [App CRs](https://github.com/giantswarm/apiextensions/tree/master/pkg/apis/application/v1alpha1)
+from apiextensions.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -18,6 +18,7 @@ type Config struct {
 	AppVersion          string
 	DisableForceUpgrade bool
 	Name                string
+	VersionLabelValue   string
 }
 
 // NewCR returns new application CR.
@@ -40,7 +41,7 @@ func NewCR(c Config) *applicationv1alpha1.App {
 			Namespace:   "giantswarm",
 			Annotations: annotations,
 			Labels: map[string]string{
-				"app-operator.giantswarm.io/version": "1.0.0",
+				"app-operator.giantswarm.io/version": c.VersionLabelValue,
 			},
 		},
 		Spec: applicationv1alpha1.AppSpec{

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -18,7 +18,6 @@ type Config struct {
 	AppVersion          string
 	DisableForceUpgrade bool
 	Name                string
-	VersionLabelValue   string
 }
 
 // NewCR returns new application CR.
@@ -41,7 +40,9 @@ func NewCR(c Config) *applicationv1alpha1.App {
 			Namespace:   "giantswarm",
 			Annotations: annotations,
 			Labels: map[string]string{
-				"app-operator.giantswarm.io/version": c.VersionLabelValue,
+				// Version is set to 0.0.0 for all control plane app CRs so
+				// they are reconciled by app-operator-unique.
+				"app-operator.giantswarm.io/version": "0.0.0",
 			},
 		},
 		Spec: applicationv1alpha1.AppSpec{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10973

~~Adds a new parameter so it can be used in opsctl.~~

Sets `app-operator.giantswarm.io/version`to  `0.0.0` for use in opsctl.