### PR TITLE
Add key functions for cluster configmap and kubeconfig names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add key functions for cluster configmap and cluster kubeconfig names.
+
 ## [3.1.1] - 2020-11-10
 
 ### Fixed

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -86,6 +86,10 @@ func IsDeleted(customResource v1alpha1.App) bool {
 	return customResource.DeletionTimestamp != nil
 }
 
+func KubeConfigContextName(customResource v1alpha1.App) string {
+	return customResource.Spec.KubeConfig.Context.Name
+}
+
 func KubeConfigFinalizer(customResource v1alpha1.App) string {
 	return fmt.Sprintf("app-operator.giantswarm.io/app-%s", customResource.GetName())
 }

--- a/pkg/key/cluster.go
+++ b/pkg/key/cluster.go
@@ -1,0 +1,25 @@
+package key
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+)
+
+const (
+	ingressControllerConfigMapName = "ingress-controller-values"
+	nginxIngressControllerAppName  = "nginx-ingress-controller-app"
+)
+
+func ClusterConfigMapName(customResource v1alpha1.App) string {
+	// A separate config map is used for Nginx Ingress Controller.
+	if AppName(customResource) == nginxIngressControllerAppName {
+		return ingressControllerConfigMapName
+	}
+
+	return fmt.Sprintf("%s-cluster-values", customResource.Namespace)
+}
+
+func ClusterKubeConfigSecretName(customResource v1alpha1.App) string {
+	return fmt.Sprintf("%s-kubeconfig", customResource.Namespace)
+}


### PR DESCRIPTION
Some extra key funcs needed for https://github.com/giantswarm/app-admission-controller/pull/19