### PR TITLE
Add key.ToChart function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `key.ToChart` function.
+
 ## [4.2.0] - 2021-01-12
 
 ### Removed

--- a/pkg/key/chart.go
+++ b/pkg/key/chart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/app/v4/pkg/annotation"
 )
@@ -29,4 +30,17 @@ func IsChartCordoned(customResource v1alpha1.Chart) bool {
 	}
 
 	return false
+}
+
+func ToChart(v interface{}) (v1alpha1.Chart, error) {
+	if v == nil {
+		return v1alpha1.Chart{}, microerror.Maskf(emptyValueError, "empty value cannot be converted to customResource")
+	}
+
+	customResource, ok := v.(*v1alpha1.Chart)
+	if !ok {
+		return v1alpha1.Chart{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Chart{}, v)
+	}
+
+	return *customResource, nil
 }

--- a/pkg/key/chart_test.go
+++ b/pkg/key/chart_test.go
@@ -1,6 +1,7 @@
 package key
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
@@ -52,5 +53,62 @@ func Test_ChartConfigMapName(t *testing.T) {
 
 	if ChartConfigMapName(obj) != expectedName {
 		t.Fatalf("chartConfigMapName %#q, want %#q", ChartConfigMapName(obj), expectedName)
+	}
+}
+
+func Test_ToChart(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          interface{}
+		expectedObject v1alpha1.Chart
+		errorMatcher   func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			input: &v1alpha1.Chart{
+				Spec: v1alpha1.ChartSpec{
+					Name:       "api",
+					Namespace:  "giantswarm",
+					TarballURL: "https://giantswarm.github.io/control-plane-catalog/api-1.0.0.tgz",
+					Version:    "1.0.0",
+				},
+			},
+			expectedObject: v1alpha1.Chart{
+				Spec: v1alpha1.ChartSpec{
+					Name:       "api",
+					Namespace:  "giantswarm",
+					TarballURL: "https://giantswarm.github.io/control-plane-catalog/api-1.0.0.tgz",
+					Version:    "1.0.0",
+				},
+			},
+		},
+		{
+			name:         "case 1: empty value",
+			input:        nil,
+			errorMatcher: IsEmptyValueError,
+		},
+		{
+			name:         "case 2: wrong type",
+			input:        &v1alpha1.AppCatalog{},
+			errorMatcher: IsWrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ToChart(tc.input)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedObject) {
+				t.Fatalf("Custom Object == %#v, want %#v", result, tc.expectedObject)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14163

We already have `key.ToApp`. This adds `key.ToChart` which will be used in the chart CR watcher in app-operator.

## Checklist

- [x] Update changelog in CHANGELOG.md.
