### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -96,7 +96,7 @@ func CordonUntilDate() string {
 }
 
 func DefaultCatalogStorageURL() string {
-	return "https://giantswarm.github.com/default-catalog"
+	return "https://giantswarm.github.io/default-catalog"
 }
 
 func InCluster(customResource v1alpha1.App) bool {


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898