### PR TITLE
Replace AppCatalog with Catalog CRD in values package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add key functions for `Catalog` CRs.
 
+### Changed
+
+- Breaking change to replace `AppCatalog ` CRD with namespace scoped `Catalog`
+CRD in `values` package.
+
 ## [4.13.0] - 2021-05-12
 
 ## [4.12.0] - 2021-05-06

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/giantswarm/app/v4
+module github.com/giantswarm/app/v5
 
-go 1.15
+go 1.16
 
 require (
 	github.com/giantswarm/apiextensions/v3 v3.26.0

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/app/v4/pkg/key"
+	"github.com/giantswarm/app/v5/pkg/key"
 )
 
 const (

--- a/pkg/values/configmap.go
+++ b/pkg/values/configmap.go
@@ -20,9 +20,9 @@ const (
 
 // MergeConfigMapData merges the data from the catalog, app and user configmaps
 // and returns a single set of values.
-func (v *Values) MergeConfigMapData(ctx context.Context, app v1alpha1.App, appCatalog v1alpha1.AppCatalog) (map[string]interface{}, error) {
+func (v *Values) MergeConfigMapData(ctx context.Context, app v1alpha1.App, catalog v1alpha1.Catalog) (map[string]interface{}, error) {
 	appConfigMapName := key.AppConfigMapName(app)
-	catalogConfigMapName := key.AppCatalogConfigMapName(appCatalog)
+	catalogConfigMapName := key.CatalogConfigMapName(catalog)
 	userConfigMapName := key.UserConfigMapName(app)
 
 	if appConfigMapName == "" && catalogConfigMapName == "" && userConfigMapName == "" {
@@ -31,7 +31,7 @@ func (v *Values) MergeConfigMapData(ctx context.Context, app v1alpha1.App, appCa
 	}
 
 	// We get the catalog level values if configured.
-	rawCatalogData, err := v.getConfigMapForCatalog(ctx, appCatalog)
+	rawCatalogData, err := v.getConfigMapForCatalog(ctx, catalog)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -107,8 +107,8 @@ func (v *Values) getConfigMapForApp(ctx context.Context, app v1alpha1.App) (map[
 	return configMap, nil
 }
 
-func (v *Values) getConfigMapForCatalog(ctx context.Context, catalog v1alpha1.AppCatalog) (map[string]string, error) {
-	configMap, err := v.getConfigMap(ctx, key.AppCatalogConfigMapName(catalog), key.AppCatalogConfigMapNamespace(catalog))
+func (v *Values) getConfigMapForCatalog(ctx context.Context, catalog v1alpha1.Catalog) (map[string]string, error) {
+	configMap, err := v.getConfigMap(ctx, key.CatalogConfigMapName(catalog), key.CatalogConfigMapNamespace(catalog))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/values/configmap.go
+++ b/pkg/values/configmap.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/app/v4/pkg/key"
+	"github.com/giantswarm/app/v5/pkg/key"
 )
 
 const (

--- a/pkg/values/configmap_test.go
+++ b/pkg/values/configmap_test.go
@@ -19,7 +19,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 	tests := []struct {
 		name         string
 		app          v1alpha1.App
-		appCatalog   v1alpha1.AppCatalog
+		catalog      v1alpha1.Catalog
 		configMaps   []*corev1.ConfigMap
 		expectedData map[string]interface{}
 		errorMatcher func(error) bool
@@ -37,7 +37,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 					Namespace: "kube-system",
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
@@ -63,7 +63,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
@@ -96,14 +96,14 @@ func Test_MergeConfigMapData(t *testing.T) {
 					Namespace: "giantswarm",
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+					Config: &v1alpha1.CatalogSpecConfig{
+						ConfigMap: &v1alpha1.CatalogSpecConfigConfigMap{
 							Name:      "test-catalog-values",
 							Namespace: "giantswarm",
 						},
@@ -144,14 +144,14 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+					Config: &v1alpha1.CatalogSpecConfig{
+						ConfigMap: &v1alpha1.CatalogSpecConfigConfigMap{
 							Name:      "test-catalog-values",
 							Namespace: "giantswarm",
 						},
@@ -202,14 +202,14 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+					Config: &v1alpha1.CatalogSpecConfig{
+						ConfigMap: &v1alpha1.CatalogSpecConfigConfigMap{
 							Name:      "test-catalog-values",
 							Namespace: "giantswarm",
 						},
@@ -265,14 +265,14 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+					Config: &v1alpha1.CatalogSpecConfig{
+						ConfigMap: &v1alpha1.CatalogSpecConfigConfigMap{
 							Name:      "test-catalog-values",
 							Namespace: "giantswarm",
 						},
@@ -334,14 +334,14 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+					Config: &v1alpha1.CatalogSpecConfig{
+						ConfigMap: &v1alpha1.CatalogSpecConfigConfigMap{
 							Name:      "test-catalog-values",
 							Namespace: "giantswarm",
 						},
@@ -390,7 +390,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 				t.Fatalf("error == %#v, want nil", err)
 			}
 
-			result, err := v.MergeConfigMapData(ctx, tc.app, tc.appCatalog)
+			result, err := v.MergeConfigMapData(ctx, tc.app, tc.catalog)
 			switch {
 			case err != nil && tc.errorMatcher == nil:
 				t.Fatalf("error == %#v, want nil", err)

--- a/pkg/values/secret.go
+++ b/pkg/values/secret.go
@@ -15,9 +15,9 @@ import (
 
 // MergeSecretData merges the data from the catalog, app and user secretss
 // and returns a single set of values.
-func (v *Values) MergeSecretData(ctx context.Context, app v1alpha1.App, appCatalog v1alpha1.AppCatalog) (map[string]interface{}, error) {
+func (v *Values) MergeSecretData(ctx context.Context, app v1alpha1.App, catalog v1alpha1.Catalog) (map[string]interface{}, error) {
 	appSecretName := key.AppSecretName(app)
-	catalogSecretName := key.AppCatalogSecretName(appCatalog)
+	catalogSecretName := key.CatalogSecretName(catalog)
 	userSecretName := key.UserSecretName(app)
 
 	if appSecretName == "" && catalogSecretName == "" && userSecretName == "" {
@@ -26,7 +26,7 @@ func (v *Values) MergeSecretData(ctx context.Context, app v1alpha1.App, appCatal
 	}
 
 	// We get the catalog level secrets if configured.
-	rawCatalogData, err := v.getSecretDataForCatalog(ctx, appCatalog)
+	rawCatalogData, err := v.getSecretDataForCatalog(ctx, catalog)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -106,8 +106,8 @@ func (v *Values) getSecretDataForApp(ctx context.Context, app v1alpha1.App) (map
 	return secret, nil
 }
 
-func (v *Values) getSecretDataForCatalog(ctx context.Context, catalog v1alpha1.AppCatalog) (map[string][]byte, error) {
-	secret, err := v.getSecret(ctx, key.AppCatalogSecretName(catalog), key.AppCatalogSecretNamespace(catalog))
+func (v *Values) getSecretDataForCatalog(ctx context.Context, catalog v1alpha1.Catalog) (map[string][]byte, error) {
+	secret, err := v.getSecret(ctx, key.CatalogSecretName(catalog), key.CatalogSecretNamespace(catalog))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/values/secret.go
+++ b/pkg/values/secret.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/app/v4/pkg/key"
+	"github.com/giantswarm/app/v5/pkg/key"
 )
 
 // MergeSecretData merges the data from the catalog, app and user secretss

--- a/pkg/values/secret_test.go
+++ b/pkg/values/secret_test.go
@@ -19,7 +19,7 @@ func Test_MergeSecretData(t *testing.T) {
 	tests := []struct {
 		name         string
 		app          v1alpha1.App
-		appCatalog   v1alpha1.AppCatalog
+		catalog      v1alpha1.Catalog
 		secrets      []*corev1.Secret
 		expectedData map[string]interface{}
 		errorMatcher func(error) bool
@@ -37,7 +37,7 @@ func Test_MergeSecretData(t *testing.T) {
 					Namespace: "kube-system",
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
@@ -63,7 +63,7 @@ func Test_MergeSecretData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
@@ -96,14 +96,14 @@ func Test_MergeSecretData(t *testing.T) {
 					Namespace: "giantswarm",
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+					Config: &v1alpha1.CatalogSpecConfig{
+						Secret: &v1alpha1.CatalogSpecConfigSecret{
 							Name:      "test-catalog-secrets",
 							Namespace: "giantswarm",
 						},
@@ -144,14 +144,14 @@ func Test_MergeSecretData(t *testing.T) {
 					Namespace: "giantswarm",
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+					Config: &v1alpha1.CatalogSpecConfig{
+						Secret: &v1alpha1.CatalogSpecConfigSecret{
 							Name:      "test-catalog-secrets",
 							Namespace: "giantswarm",
 						},
@@ -202,14 +202,14 @@ func Test_MergeSecretData(t *testing.T) {
 					Namespace: "giantswarm",
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+					Config: &v1alpha1.CatalogSpecConfig{
+						Secret: &v1alpha1.CatalogSpecConfigSecret{
 							Name:      "test-catalog-secrets",
 							Namespace: "giantswarm",
 						},
@@ -268,14 +268,14 @@ func Test_MergeSecretData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
-				Spec: v1alpha1.AppCatalogSpec{
+				Spec: v1alpha1.CatalogSpec{
 					Title: "test-catalog",
-					Config: v1alpha1.AppCatalogSpecConfig{
-						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+					Config: &v1alpha1.CatalogSpecConfig{
+						Secret: &v1alpha1.CatalogSpecConfigSecret{
 							Name:      "test-catalog-secrets",
 							Namespace: "giantswarm",
 						},
@@ -338,7 +338,7 @@ func Test_MergeSecretData(t *testing.T) {
 					},
 				},
 			},
-			appCatalog: v1alpha1.AppCatalog{
+			catalog: v1alpha1.Catalog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-catalog",
 				},
@@ -375,7 +375,7 @@ func Test_MergeSecretData(t *testing.T) {
 				t.Fatalf("error == %#v, want nil", err)
 			}
 
-			result, err := v.MergeSecretData(ctx, tc.app, tc.appCatalog)
+			result, err := v.MergeSecretData(ctx, tc.app, tc.catalog)
 			switch {
 			case err != nil && tc.errorMatcher == nil:
 				t.Fatalf("error == %#v, want nil", err)

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -45,13 +45,13 @@ func New(config Config) (*Values, error) {
 
 // MergeAll merges both configmap and secret values to produce a single set of
 // values that can be passed to Helm.
-func (v *Values) MergeAll(ctx context.Context, app v1alpha1.App, appCatalog v1alpha1.AppCatalog) (map[string]interface{}, error) {
-	configMapData, err := v.MergeConfigMapData(ctx, app, appCatalog)
+func (v *Values) MergeAll(ctx context.Context, app v1alpha1.App, catalog v1alpha1.Catalog) (map[string]interface{}, error) {
+	configMapData, err := v.MergeConfigMapData(ctx, app, catalog)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	secretData, err := v.MergeSecretData(ctx, app, appCatalog)
+	secretData, err := v.MergeSecretData(ctx, app, catalog)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
This is just prep for using the Catalog CRD in https://github.com/giantswarm/kubectl-gs/pull/365 because it uses the values package.

@tomahawk28 This is a breaking change but WDYT can we just do a major version bump?

