### PR TITLE
Add another LoadCRDs function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `crd.LoadCRDs`, `crd.LoadCRD` functions.
 - Add key functions for `Catalog` CRs.
 
 ### Changed

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -84,7 +84,7 @@ func NewCRDGetter(config Config) (*CRDGetter, error) {
 	return crdGetter, nil
 }
 
-func (g CRDGetter) LoadCRD(ctx context.Context, group, kind string) (*apiextensionsv1.CustomResourceDefinition, error) {
+func (g CRDGetter) LoadCRDs(ctx context.Context) ([]*apiextensionsv1.CustomResourceDefinition, error) {
 	var crds []*apiextensionsv1.CustomResourceDefinition
 	charts := []string{
 		"crds-common",
@@ -101,6 +101,15 @@ func (g CRDGetter) LoadCRD(ctx context.Context, group, kind string) (*apiextensi
 		}
 
 		crds = append(crds, chartCRDs...)
+	}
+
+	return crds, nil
+}
+
+func (g CRDGetter) LoadCRD(ctx context.Context, group, kind string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	crds, err := g.LoadCRDs(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
 	for _, crd := range crds {


### PR DESCRIPTION
Toward giantswarm/roadmap#219

At some points, we need to load whole CRDs from the github, such as opsctl. https://github.com/giantswarm/opsctl/blob/3d77e8098250de3b70cc188504c3897937e5d30b/command/ensure/crds/command.go#L234-L264