### PR TITLE
Reject app version label with legacy 1.0.0 value

### DIFF
--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -12,6 +12,9 @@ import (
 
 const (
 	ChartOperatorAppName = "chart-operator"
+	// LegacyAppVersionLabel was used for app CRs deployed with Helm 2.
+	// We now always default the value for this label.
+	LegacyAppVersionLabel = "1.0.0"
 )
 
 func AppConfigMapName(customResource v1alpha1.App) string {

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -15,9 +15,10 @@ import (
 
 const (
 	catalogNotFoundTemplate         = "catalog %#q not found"
-	labelNotFoundTemplate           = "label %#q not found"
 	nameTooLongTemplate             = "name %#q is %d chars and exceeds max length of %d chars"
 	namespaceNotFoundReasonTemplate = "namespace is not specified for %s %#q"
+	labelInvalidValueTemplate       = "label %#q has invalid value %#q"
+	labelNotFoundTemplate           = "label %#q not found"
 	resourceNotFoundTemplate        = "%s %#q in namespace %#q not found"
 
 	defaultCatalogName = "default"
@@ -204,6 +205,9 @@ func (v *Validator) validateKubeConfig(ctx context.Context, cr v1alpha1.App) err
 func (v *Validator) validateLabels(ctx context.Context, cr v1alpha1.App) error {
 	if key.VersionLabel(cr) == "" {
 		return microerror.Maskf(validationError, labelNotFoundTemplate, label.AppOperatorVersion)
+	}
+	if key.VersionLabel(cr) == key.LegacyAppVersionLabel {
+		return microerror.Maskf(validationError, labelInvalidValueTemplate, label.AppOperatorVersion, key.VersionLabel(cr))
 	}
 
 	return nil

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -543,6 +543,31 @@ func Test_ValidateApp(t *testing.T) {
 			},
 			expectedErr: "validation error: name `cluster-autoscaler-1.2.2-2b060b8bda545a7b6aeff1b8cb13951181ae30d3` is 65 chars and exceeds max length of 53 chars",
 		},
+		{
+			name: "case 16: legacy version label is rejected",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "1.0.0",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					Version: "1.4.0",
+				},
+			},
+			catalogs: []*v1alpha1.AppCatalog{
+				newTestCatalog("giantswarm"),
+			},
+			expectedErr: "validation error: label `app-operator.giantswarm.io/version` has invalid value `1.0.0`",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Towards giantswarm/giantswarm#18349

In https://github.com/giantswarm/app-admission-controller/pull/155 we will always default the version to the correct value if its 1.0.0.

This extends the validation rules so if the defaulting fails we reject the CR.