### PR TITLE
Check for nil or empty .metadata.name in catalog validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check for nil or empty `.metadata.Name`  when validating `.spec.catalog`.
+
 ## [5.2.0] - 2021-08-16
 
 ### Changed

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -103,7 +103,7 @@ func (v *Validator) validateCatalog(ctx context.Context, cr v1alpha1.App) error 
 		break
 	}
 
-	if catalog == nil {
+	if catalog == nil || catalog.Name == "" {
 		return microerror.Maskf(validationError, catalogNotFoundTemplate, key.CatalogName(cr))
 	}
 

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -133,7 +133,7 @@ func Test_ValidateApp(t *testing.T) {
 					},
 				},
 				Spec: v1alpha1.AppSpec{
-					Catalog:   "control-plane-catalog",
+					Catalog:   "missing",
 					Name:      "dex-app",
 					Namespace: "giantswarm",
 					KubeConfig: v1alpha1.AppSpecKubeConfig{
@@ -142,7 +142,10 @@ func Test_ValidateApp(t *testing.T) {
 					Version: "1.2.2",
 				},
 			},
-			expectedErr: "validation error: catalog `control-plane-catalog` not found",
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("control-plane-catalog", "giantswarm"),
+			},
+			expectedErr: "validation error: catalog `missing` not found",
 		},
 		{
 			name: "case 4: spec.config.configMap not found",


### PR DESCRIPTION
Towards giantswarm/giantswarm#18349