### PR TITLE
Validate kubeconfig secret name is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Validate kubeconfig secret name is set when in cluster is false.
+
 ## [5.3.0] - 2021-09-15
 
 ### Added

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -604,6 +604,38 @@ func Test_ValidateApp(t *testing.T) {
 				newTestConfigMap("nginx-ingress-user-values", "eggs2"),
 			},
 		},
+		{
+			name: "case 19: spec.kubeConfig.secret no name specified",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "2.6.0",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						Context: v1alpha1.AppSpecKubeConfigContext{
+							Name: "eggs2-kubeconfig",
+						},
+						InCluster: false,
+						Secret: v1alpha1.AppSpecKubeConfigSecret{
+							Name:      "",
+							Namespace: "default",
+						},
+					},
+					Version: "1.4.0",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("giantswarm", "default"),
+			},
+			expectedErr: "validation error: name is not specified for kubeconfig secret",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
When "in cluster" is false we  validate that `.spec.kubeConfig.secret.namespace` is set but not `.spec.kubeConfig.secret.name`.

This results in a strange error in the clients resource. This adds the missing validation.

```
E 11/08 14:43:43 default/hello-world clients retrying due to error | operatorkit/v5/pkg/resource/wrapper/retryresource/basic_resource.go:83 | controller=app-operator-app | event=delete | loop=52 | stack=map[annotation:resource name may not be empty kind:unknown stack:[map[file:/go/pkg/mod/github.com/giantswarm/kubeconfig/v4@v4.1.0/kubeconfig.go line:122] map[file:/go/pkg/mod/github.com/giantswarm/kubeconfig/v4@v4.1.0/kubeconfig.go line:45] map[file:/root/project/service/internal/clientcache/cache.go line:138] map[file:/root/project/service/internal/clientcache/cache.go line:97] map[file:/root/project/service/controller/app/resource/clients/resource.go line:112] map[file:/root/project/service/controller/app/resource/clients/delete.go line:20] 
```