### PR TITLE
Skip validation of app dependencies when managed-by label equals flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Skip validation of configmap and secret names when `giantswarm.io/managedby`
+label is set to `flux`.
+
 ## [5.4.0] - 2021-11-09
 
 ### Added

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -128,6 +128,19 @@ func IsDeleted(customResource v1alpha1.App) bool {
 	return customResource.DeletionTimestamp != nil
 }
 
+// IsManagedByFlux returns true if the giantswarm.io/managed-by label is set to
+// flux and is being validated by app-admission-controller. When true we skip
+// validating configmap and secret names. This simplifies managing these
+// resources with Flux. We still perform the validation in app-operator which
+// sets the App CR status.
+func IsManagedByFlux(customResource v1alpha1.App, projectName string) bool {
+	if projectName != "app-admission-controller" {
+		return false
+	}
+
+	return customResource.Labels[label.ManagedBy] == "flux"
+}
+
 func KubeConfigContextName(customResource v1alpha1.App) string {
 	return customResource.Spec.KubeConfig.Context.Name
 }

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -157,6 +157,10 @@ func KubeConfigSecretNamespace(customResource v1alpha1.App) string {
 	return customResource.Spec.KubeConfig.Secret.Namespace
 }
 
+func ManagedByLabel(customResource v1alpha1.App) string {
+	return customResource.Labels[label.ManagedBy]
+}
+
 func Namespace(customResource v1alpha1.App) string {
 	return customResource.Spec.Namespace
 }

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -113,6 +113,10 @@ func (v *Validator) validateCatalog(ctx context.Context, cr v1alpha1.App) error 
 }
 
 func (v *Validator) validateConfig(ctx context.Context, cr v1alpha1.App) error {
+	if key.IsManagedByFlux(cr, v.projectName) {
+		return nil
+	}
+
 	if key.AppConfigMapName(cr) != "" {
 		ns := key.AppConfigMapNamespace(cr)
 		if ns == "" {
@@ -208,6 +212,10 @@ func (v *Validator) validateNamespaceConfig(ctx context.Context, cr v1alpha1.App
 }
 
 func (v *Validator) validateKubeConfig(ctx context.Context, cr v1alpha1.App) error {
+	if key.IsManagedByFlux(cr, v.projectName) {
+		return nil
+	}
+
 	if !key.InCluster(cr) {
 		ns := key.KubeConfigSecretNamespace(cr)
 		if ns == "" {
@@ -305,6 +313,10 @@ func (v *Validator) validateMetadataConstraints(ctx context.Context, cr v1alpha1
 }
 
 func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) error {
+	if key.IsManagedByFlux(cr, v.projectName) {
+		return nil
+	}
+
 	if key.UserConfigMapName(cr) != "" {
 		// NGINX Ingress Controller is no longer a pre-installed app
 		// managed by cluster-operator. So we don't need to restrict

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -636,6 +636,44 @@ func Test_ValidateApp(t *testing.T) {
 			},
 			expectedErr: "validation error: name is not specified for kubeconfig secret",
 		},
+		{
+			name: "case 20: skip validation when giantswarm.io/managed-by label equals flux",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "2.6.0",
+						label.ManagedBy:          "flux",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						Context: v1alpha1.AppSpecKubeConfigContext{
+							Name: "eggs2-kubeconfig",
+						},
+						InCluster: false,
+						Secret: v1alpha1.AppSpecKubeConfigSecret{
+							Name:      "",
+							Namespace: "default",
+						},
+					},
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
+							Name:      "kiam-user-values",
+							Namespace: "eggs2",
+						},
+					},
+					Version: "1.4.0",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("giantswarm", "default"),
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -659,7 +697,8 @@ func Test_ValidateApp(t *testing.T) {
 				K8sClient: clientgofake.NewSimpleClientset(k8sObjs...),
 				Logger:    microloggertest.New(),
 
-				Provider: "aws",
+				ProjectName: "app-admission-controller",
+				Provider:    "aws",
 			}
 			r, err := NewValidator(c)
 			if err != nil {

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -929,7 +929,8 @@ func Test_ValidateMetadataConstraints(t *testing.T) {
 				K8sClient: clientgofake.NewSimpleClientset(),
 				Logger:    microloggertest.New(),
 
-				Provider: "aws",
+				ProjectName: "app-admission-controller",
+				Provider:    "aws",
 			}
 			r, err := NewValidator(c)
 			if err != nil {
@@ -1097,7 +1098,8 @@ func Test_ValidateNamespace(t *testing.T) {
 				K8sClient: clientgofake.NewSimpleClientset(),
 				Logger:    microloggertest.New(),
 
-				Provider: "aws",
+				ProjectName: "app-admission-controller",
+				Provider:    "aws",
 			}
 			r, err := NewValidator(c)
 			if err != nil {

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -12,7 +12,8 @@ type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
-	Provider string
+	ProjectName string
+	Provider    string
 }
 
 type Validator struct {
@@ -20,7 +21,8 @@ type Validator struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
-	provider string
+	projectName string
+	provider    string
 }
 
 func NewValidator(config Config) (*Validator, error) {
@@ -34,6 +36,9 @@ func NewValidator(config Config) (*Validator, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
 	if config.Provider == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
 	}
@@ -43,7 +48,8 @@ func NewValidator(config Config) (*Validator, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
-		provider: config.Provider,
+		projectName: config.ProjectName,
+		provider:    config.Provider,
 	}
 
 	return validator, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19700

Related to https://github.com/giantswarm/workload-clusters-fleet-demo/pull/1

We can simplify our Flux setup to include user values configmaps and secrets in the same directory as the app CR.

To do this we loosen the validation in app-admission-controller if the label `giantswarm.io/managed-by` is set to `flux`.
We keep the logic in the validation resource in app-operator which sets the app CR status.
