### PR TITLE
Allow setting `.spec.kubeConfig.inCluster` when generating app CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow setting `.spec.kubeConfig.inCluster` when generating app CRs.
+
 ## [5.5.0] - 2021-11-25
 
 ### Added

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -20,6 +20,7 @@ type Config struct {
 	AppVersion          string
 	ConfigVersion       string
 	DisableForceUpgrade bool
+	InCluster           bool
 	Name                string
 	Namespace           string
 	UserConfigMapName   string
@@ -73,7 +74,7 @@ func NewCR(c Config) *applicationv1alpha1.App {
 		Spec: applicationv1alpha1.AppSpec{
 			Catalog: c.AppCatalog,
 			KubeConfig: applicationv1alpha1.AppSpecKubeConfig{
-				InCluster: true,
+				InCluster: c.InCluster,
 			},
 			Name:       c.AppName,
 			Namespace:  c.AppNamespace,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19942

When using `opsctl deploy` with the `--cluster` flag for workload cluster apps we need to set inCluster to false. 