### PR TITLE
Add ValidateAppUpdate to ensure .spec.namespace is immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `ValidateAppUpdate` to ensure `.spec.Namespace` is immutable.
+- Add `ValidateAppUpdate` to ensure `.spec.Namespace` is immutable in App CRs.
 
 ## [6.1.0] - 2021-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ValidateAppUpdate` to ensure `.spec.Namespace` is immutable.
+
 ## [6.1.0] - 2021-12-09
 
 ### Added

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -78,6 +78,15 @@ func (v *Validator) ValidateApp(ctx context.Context, app v1alpha1.App) (bool, er
 	return true, nil
 }
 
+func (v *Validator) ValidateAppUpdate(ctx context.Context, app, currentApp v1alpha1.App) (bool, error) {
+	err := v.validateNamespaceUpdate(ctx, app, currentApp)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
 func (v *Validator) validateCatalog(ctx context.Context, cr v1alpha1.App) error {
 	var err error
 
@@ -332,6 +341,15 @@ func (v *Validator) validateMetadataConstraints(ctx context.Context, cr v1alpha1
 				}
 			}
 		}
+	}
+
+	return nil
+}
+
+func (v *Validator) validateNamespaceUpdate(ctx context.Context, app, currentApp v1alpha1.App) error {
+	if key.Namespace(app) != key.Namespace(currentApp) {
+		return microerror.Maskf(validationError, "namespace for app %#q cannot be changed from %#q to %#q", app.Name,
+			key.Namespace(currentApp), key.Namespace(app))
 	}
 
 	return nil

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -348,7 +348,7 @@ func (v *Validator) validateMetadataConstraints(ctx context.Context, cr v1alpha1
 
 func (v *Validator) validateNamespaceUpdate(ctx context.Context, app, currentApp v1alpha1.App) error {
 	if key.Namespace(app) != key.Namespace(currentApp) {
-		return microerror.Maskf(validationError, "namespace for app %#q cannot be changed from %#q to %#q", app.Name,
+		return microerror.Maskf(validationError, "target namespace for app %#q cannot be changed from %#q to %#q", app.Name,
 			key.Namespace(currentApp), key.Namespace(app))
 	}
 

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -714,6 +715,114 @@ func Test_ValidateApp(t *testing.T) {
 			}
 
 			_, err = r.ValidateApp(ctx, tc.obj)
+			switch {
+			case err != nil && tc.expectedErr == "":
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.expectedErr != "":
+				t.Fatalf("error == nil, want non-nil")
+			}
+
+			if err != nil && tc.expectedErr != "" {
+				if !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("error == %#v, want %#v ", err.Error(), tc.expectedErr)
+				}
+
+			}
+		})
+	}
+}
+
+func Test_ValidateAppUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		obj         v1alpha1.App
+		currentApp  v1alpha1.App
+		expectedErr string
+	}{
+		{
+			name: "case 0: flawless",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					Version:   "1.4.0",
+				},
+			},
+			currentApp: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					Version:   "1.4.0",
+				},
+			},
+		},
+		{
+			name: "case 1: changed namespace is rejected",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "default",
+					Version:   "1.4.0",
+				},
+			},
+			currentApp: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					Version:   "1.4.0",
+				},
+			},
+			expectedErr: "validation error: namespace for app `kiam` cannot be changed from `kube-system` to `default`",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			scheme := runtime.NewScheme()
+			_ = v1alpha1.AddToScheme(scheme)
+
+			fakeCtrlClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+
+			c := Config{
+				G8sClient: fakeCtrlClient,
+				K8sClient: clientgofake.NewSimpleClientset(),
+				Logger:    microloggertest.New(),
+
+				ProjectName: "app-admission-controller",
+				Provider:    "aws",
+			}
+			r, err := NewValidator(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			_, err = r.ValidateAppUpdate(ctx, tc.obj, tc.currentApp)
 			switch {
 			case err != nil && tc.expectedErr == "":
 				t.Fatalf("error == %#v, want nil", err)

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -794,7 +794,7 @@ func Test_ValidateAppUpdate(t *testing.T) {
 					Version:   "1.4.0",
 				},
 			},
-			expectedErr: "validation error: namespace for app `kiam` cannot be changed from `kube-system` to `default`",
+			expectedErr: "validation error: target namespace for app `kiam` cannot be changed from `kube-system` to `default`",
 		},
 	}
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#20153

Error message includes target namespace to differentiate from the namespace of the app CR.

```
target namespace for app `nginx-ingress-controller-app` cannot be changed from `kube-system` to `default`
```

```
kubectl patch app -n xk38a nginx-ingress-controller-app --type='json' -p '[{
  "op": "replace",
  "path": "/spec/namespace",
  "value": "default"
}]'
Error from server: admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: validation error: target namespace for app `nginx-ingress-controller-app` cannot be changed from `kube-system` to `default`
```