### PR TITLE
Validating target namespace

### DIFF
--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -182,7 +182,7 @@ func (v *Validator) validateName(ctx context.Context, cr v1alpha1.App) error {
 }
 
 // We make sure users cannot create in-cluster Apps outside their organization
-// or WC namespaces. Otherwise `.spec.namespace` could be use to override permissions.
+// or WC namespaces. Otherwise `.spec.namespace` could be exploited to override permissions.
 func (v *Validator) validateTargetNamespace(ctx context.Context, cr v1alpha1.App) error {
 	if key.InCluster(cr) {
 		if !strings.EqualFold(cr.Namespace, "giantswarm") {

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -19,7 +19,7 @@ const (
 	catalogNotFoundTemplate         = "catalog %#q not found"
 	nameTooLongTemplate             = "name %#q is %d chars and exceeds max length of %d chars"
 	nameNotFoundReasonTemplate      = "name is not specified for %s"
-	targetNamespaceNotAllowed       = "target namespace %s is not allowed"
+	targetNamespaceNotAllowed       = "target namespace %s is not allowed for in-cluster apps"
 	namespaceNotFoundReasonTemplate = "namespace is not specified for %s %#q"
 	labelInvalidValueTemplate       = "label %#q has invalid value %#q"
 	labelNotFoundTemplate           = "label %#q not found"

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -183,12 +183,12 @@ func (v *Validator) validateName(ctx context.Context, cr v1alpha1.App) error {
 // We make sure users cannot create in-cluster Apps outside their organization
 // or WC namespaces. Otherwise `.spec.namespace` could be exploited to override permissions.
 func (v *Validator) validateTargetNamespace(ctx context.Context, cr v1alpha1.App) error {
-	if key.InCluster(cr) {
-		if cr.Namespace != "giantswarm" {
-			if cr.Namespace != cr.Spec.Namespace {
-				return microerror.Maskf(validationError, targetNamespaceNotAllowed, cr.Spec.Namespace)
-			}
-		}
+	isInCluster := key.InCluster(cr)
+	isNotGs := cr.Namespace != "giantswarm"
+	isOutsideOrg := cr.Namespace != cr.Spec.Namespace
+
+	if isInCluster && isNotGs && isOutsideOrg {
+		return microerror.Maskf(validationError, targetNamespaceNotAllowed, cr.Spec.Namespace)
 	}
 
 	return nil

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8smetadata/pkg/label"
@@ -185,8 +184,8 @@ func (v *Validator) validateName(ctx context.Context, cr v1alpha1.App) error {
 // or WC namespaces. Otherwise `.spec.namespace` could be exploited to override permissions.
 func (v *Validator) validateTargetNamespace(ctx context.Context, cr v1alpha1.App) error {
 	if key.InCluster(cr) {
-		if !strings.EqualFold(cr.Namespace, "giantswarm") {
-			if !strings.EqualFold(cr.Namespace, cr.Spec.Namespace) {
+		if cr.Namespace != "giantswarm" {
+			if cr.Namespace != cr.Spec.Namespace {
 				return microerror.Maskf(validationError, targetNamespaceNotAllowed, cr.Spec.Namespace)
 			}
 		}

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -578,7 +578,7 @@ func Test_ValidateApp(t *testing.T) {
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
-					Namespace: "eggs2",
+					Namespace: "giantswarm",
 					Labels: map[string]string{
 						label.AppOperatorVersion: "0.0.0",
 					},
@@ -677,7 +677,7 @@ func Test_ValidateApp(t *testing.T) {
 			},
 		},
 		{
-			name: "application not allowed outside org namespace",
+			name: ".spec.namespace for in-cluster app not allowed outside org namespace",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -699,10 +699,35 @@ func Test_ValidateApp(t *testing.T) {
 			catalogs: []*v1alpha1.Catalog{
 				newTestCatalog("giantswarm", "default"),
 			},
-			expectedErr: "validation error: namespace kube-system is not allowed",
+			expectedErr: "validation error: target namespace kube-system is not allowed",
 		},
 		{
-			name: "application allowed in the org namespace",
+			name: ".spec.namespace for in-cluster app not allowed outside WC namespace",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "eggs2",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "2.6.0",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					Version: "1.4.0",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("giantswarm", "default"),
+			},
+			expectedErr: "validation error: target namespace kube-system is not allowed",
+		},
+		{
+			name: ".spec.namespace for in-cluster app allowed when it matches org namespace",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -28,7 +29,7 @@ func Test_ValidateApp(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name: "case 0: flawless flow",
+			name: "flawless flow",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -78,7 +79,7 @@ func Test_ValidateApp(t *testing.T) {
 			},
 		},
 		{
-			name: "case 1: flawless in-cluster",
+			name: "flawless in-cluster",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -102,7 +103,7 @@ func Test_ValidateApp(t *testing.T) {
 			},
 		},
 		{
-			name: "case 2: missing version label",
+			name: "missing version label",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -124,7 +125,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: label `app-operator.giantswarm.io/version` not found",
 		},
 		{
-			name: "case 3: spec.catalog not found",
+			name: "spec.catalog not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -149,7 +150,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: catalog `missing` not found",
 		},
 		{
-			name: "case 4: spec.config.configMap not found",
+			name: "spec.config.configMap not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -180,7 +181,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "app config map not found error: configmap `dex-app-values` in namespace `giantswarm` not found",
 		},
 		{
-			name: "case 5: spec.config.configMap no namespace specified",
+			name: "spec.config.configMap no namespace specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -211,7 +212,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: namespace is not specified for configmap `dex-app-values`",
 		},
 		{
-			name: "case 6: spec.config.secret not found",
+			name: "spec.config.secret not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -242,7 +243,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: secret `dex-app-secrets` in namespace `giantswarm` not found",
 		},
 		{
-			name: "case 7: spec.config.secret no namespace specified",
+			name: "spec.config.secret no namespace specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -273,7 +274,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: namespace is not specified for secret `dex-app-secrets`",
 		},
 		{
-			name: "case 8: spec.kubeConfig.secret not found",
+			name: "pec.kubeConfig.secret not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -305,7 +306,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "kube config not found error: kubeconfig secret `eggs2-kubeconfig` in namespace `eggs2` not found",
 		},
 		{
-			name: "case 9: spec.kubeConfig.secret no namespace specified",
+			name: "spec.kubeConfig.secret no namespace specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -337,7 +338,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: namespace is not specified for kubeconfig secret `eggs2-kubeconfig`",
 		},
 		{
-			name: "case 10: spec.userConfig.configMap not found",
+			name: "spec.userConfig.configMap not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -368,7 +369,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: configmap `dex-app-user-values` in namespace `giantswarm` not found",
 		},
 		{
-			name: "case 11: spec.userConfig.configMap no namespace specified",
+			name: "spec.userConfig.configMap no namespace specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -399,7 +400,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: namespace is not specified for configmap `dex-app-user-values`",
 		},
 		{
-			name: "case 12: spec.userConfig.secret not found",
+			name: "spec.userConfig.secret not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -430,7 +431,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: secret `dex-app-user-secrets` in namespace `giantswarm` not found",
 		},
 		{
-			name: "case 13: spec.userConfig.secret no namespace specified",
+			name: "spec.userConfig.secret no namespace specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dex-app-unique",
@@ -461,7 +462,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: namespace is not specified for secret `dex-app-user-secrets`",
 		},
 		{
-			name: "case 14: spec.userConfig.configMap.name incorrect for default catalog app",
+			name: "spec.userConfig.configMap.name incorrect for default catalog app",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -492,7 +493,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: user configmap must be named `kiam-user-values` for app in default catalog",
 		},
 		{
-			name: "case 15: spec.userConfig.secret.name incorrect for default catalog app",
+			name: "spec.userConfig.secret.name incorrect for default catalog app",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -523,7 +524,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: user secret must be named `kiam-user-secrets` for app in default catalog",
 		},
 		{
-			name: "case 16: metadata.name exceeds max length",
+			name: "metadata.name exceeds max length",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster-autoscaler-1.2.2-2b060b8bda545a7b6aeff1b8cb13951181ae30d3",
@@ -548,7 +549,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: name `cluster-autoscaler-1.2.2-2b060b8bda545a7b6aeff1b8cb13951181ae30d3` is 65 chars and exceeds max length of 53 chars",
 		},
 		{
-			name: "case 17: legacy version label is rejected",
+			name: "legacy version label is rejected",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -573,7 +574,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: label `app-operator.giantswarm.io/version` has invalid value `1.0.0`",
 		},
 		{
-			name: "case 18: nginx user values configmap name is not restricted",
+			name: "nginx user values configmap name is not restricted",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -606,7 +607,7 @@ func Test_ValidateApp(t *testing.T) {
 			},
 		},
 		{
-			name: "case 19: spec.kubeConfig.secret no name specified",
+			name: "spec.kubeConfig.secret no name specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -638,7 +639,7 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: name is not specified for kubeconfig secret",
 		},
 		{
-			name: "case 20: skip validation when giantswarm.io/managed-by label equals flux",
+			name: "skip validation when giantswarm.io/managed-by label equals flux",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
@@ -675,10 +676,59 @@ func Test_ValidateApp(t *testing.T) {
 				newTestCatalog("giantswarm", "default"),
 			},
 		},
+		{
+			name: "application not allowed outside org namespace",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "org-eggs2",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "2.6.0",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					Version: "1.4.0",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("giantswarm", "default"),
+			},
+			expectedErr: "validation error: namespace kube-system is not allowed",
+		},
+		{
+			name: "application allowed in the org namespace",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam",
+					Namespace: "org-eggs2",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "2.6.0",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "org-eggs2",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					Version: "1.4.0",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("giantswarm", "default"),
+			},
+		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			g8sObjs := make([]runtime.Object, 0)
 			for _, cat := range tc.catalogs {
 				g8sObjs = append(g8sObjs, cat)


### PR DESCRIPTION
### Description

Related issue: https://github.com/giantswarm/giantswarm/issues/19485

This PR introduces restrictions on the `.spec.namespace`, so users won't be able to exploit it to install apps outside their namespaces and clusters.

### App Admission Controller tests

1. This App CR is NOT accepted:

```yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: hello-world
  namespace: c2fv2
spec:
  catalog: giantswarm
  name: hello-world-app
  version: 0.1.0
  namespace: kube-system
  kubeConfig:
    inCluster: true
```

with the error:

```
Error from server: error when creating "app.yaml": admission webhook "apps.app-admission-controller.giantswarm.io" denied the request: validation error: target namespace kube-system is not allowed
```

2. This App CR is accepted as it goes to the WC:

```yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: hello-world
  namespace: c2fv2
spec:
  catalog: giantswarm
  name: hello-world-app
  version: 0.1.0
  namespace: kube-system
  kubeConfig:
    context:
      name: c2fv2
    inCluster: false
    secret:
      name: c2fv2-kubeconfig
      namespace: c2fv2
```

3. This App CR is accepted as it is managed in the `giantswarm` namespace by us:

```yaml
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: hello-world
  namespace: giantswarm
spec:
  catalog: giantswarm
  name: hello-world-app
  version: 0.1.0
  namespace: kube-system
  kubeConfig:
    inCluster: true
```
