### PR TITLE
Skipping CM and Secret validation for Flux-managed Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `validateResourcesExist` flag to Validator for enabling/disabling `key.IsManagedByFlux` validation.
+
+### Changed
+
+- Narrow down the `key.IsManagedByFlux` scope to validating ConfigMap and Secrets existence.
+
 ## [6.4.0] - 2022-01-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `validateResourcesExist` flag to Validator for enabling/disabling `key.IsManagedByFlux` validation.
+- Add `validateResourcesExist` flag to Validator for enabling/disabling support for `key.IsManagedByFlux`.
 
 ### Changed
 
-- Narrow down the `key.IsManagedByFlux` scope to validating ConfigMap and Secrets existence.
+- Narrow down the `key.IsManagedByFlux` impact on validation. It now skips only ConfigMap and Secret existence checks.
 
 ## [6.4.0] - 2022-01-18
 

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -397,7 +397,7 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 		}
 
 		_, err := v.k8sClient.CoreV1().ConfigMaps(ns).Get(ctx, key.UserConfigMapName(cr), metav1.GetOptions{})
-		if key.IsManagedByFlux(cr, "app-admission-controller") {
+		if key.IsManagedByFlux(cr, v.projectName) {
 			v.logger.Debugf(ctx, "skipping validation of app '%s/%s' dependencies due to '%s=%s' label", cr.Namespace, cr.Name, label.ManagedBy, key.ManagedByLabel(cr))
 			return nil
 		} else if apierrors.IsNotFound(err) {
@@ -421,7 +421,7 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 		}
 
 		_, err := v.k8sClient.CoreV1().Secrets(key.UserSecretNamespace(cr)).Get(ctx, key.UserSecretName(cr), metav1.GetOptions{})
-		if key.IsManagedByFlux(cr, "app-admission-controller") {
+		if key.IsManagedByFlux(cr, v.projectName) {
 			v.logger.Debugf(ctx, "skipping validation of app '%s/%s' dependencies due to '%s=%s' label", cr.Namespace, cr.Name, label.ManagedBy, key.ManagedByLabel(cr))
 			return nil
 		} else if apierrors.IsNotFound(err) {

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -397,7 +397,10 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 		}
 
 		_, err := v.k8sClient.CoreV1().ConfigMaps(ns).Get(ctx, key.UserConfigMapName(cr), metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
+		if key.IsManagedByFlux(cr, "app-admission-controller") {
+			v.logger.Debugf(ctx, "skipping validation of app '%s/%s' dependencies due to '%s=%s' label", cr.Namespace, cr.Name, label.ManagedBy, key.ManagedByLabel(cr))
+			return nil
+		} else if apierrors.IsNotFound(err) {
 			return microerror.Maskf(validationError, resourceNotFoundTemplate, "configmap", key.UserConfigMapName(cr), ns)
 		} else if err != nil {
 			return microerror.Mask(err)
@@ -418,7 +421,10 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 		}
 
 		_, err := v.k8sClient.CoreV1().Secrets(key.UserSecretNamespace(cr)).Get(ctx, key.UserSecretName(cr), metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
+		if key.IsManagedByFlux(cr, "app-admission-controller") {
+			v.logger.Debugf(ctx, "skipping validation of app '%s/%s' dependencies due to '%s=%s' label", cr.Namespace, cr.Name, label.ManagedBy, key.ManagedByLabel(cr))
+			return nil
+		} else if apierrors.IsNotFound(err) {
 			return microerror.Maskf(validationError, resourceNotFoundTemplate, "secret", key.UserSecretName(cr), ns)
 		} else if err != nil {
 			return microerror.Mask(err)

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -21,13 +21,13 @@ func Test_ValidateApp(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name        string
-		obj         v1alpha1.App
-		catalogs    []*v1alpha1.Catalog
-		configMaps  []*corev1.ConfigMap
-		secrets     []*corev1.Secret
-		conditional bool
-		expectedErr string
+		name                   string
+		obj                    v1alpha1.App
+		catalogs               []*v1alpha1.Catalog
+		configMaps             []*corev1.ConfigMap
+		secrets                []*corev1.Secret
+		validateResourcesExist bool
+		expectedErr            string
 	}{
 		{
 			name: "flawless flow",
@@ -337,7 +337,7 @@ func Test_ValidateApp(t *testing.T) {
 			catalogs: []*v1alpha1.Catalog{
 				newTestCatalog("giantswarm", "default"),
 			},
-			conditional: true,
+			validateResourcesExist: true,
 		},
 		{
 			name: "missing spec.kubeConfig.secret not allowed when managed by Flux on uncoditional validation",
@@ -465,7 +465,7 @@ func Test_ValidateApp(t *testing.T) {
 			catalogs: []*v1alpha1.Catalog{
 				newTestCatalog("control-plane-catalog", "default"),
 			},
-			conditional: true,
+			validateResourcesExist: true,
 		},
 		{
 			name: "missing spec.userConfig.configMap not allowed when managed by Flux on unconditional validation",
@@ -591,7 +591,7 @@ func Test_ValidateApp(t *testing.T) {
 			catalogs: []*v1alpha1.Catalog{
 				newTestCatalog("control-plane-catalog", "giantswarm"),
 			},
-			conditional: true,
+			validateResourcesExist: true,
 		},
 		{
 			name: "missing spec.userConfig.secret not allowed when managed by Flux on unconditional validation",
@@ -938,9 +938,9 @@ func Test_ValidateApp(t *testing.T) {
 				K8sClient: clientgofake.NewSimpleClientset(k8sObjs...),
 				Logger:    microloggertest.New(),
 
-				ProjectName: "app-admission-controller",
-				Provider:    "aws",
-				Conditional: tc.conditional,
+				ProjectName:            "app-admission-controller",
+				Provider:               "aws",
+				ValidateResourcesExist: tc.validateResourcesExist,
 			}
 			r, err := NewValidator(c)
 			if err != nil {

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -369,6 +369,37 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: configmap `dex-app-user-values` in namespace `giantswarm` not found",
 		},
 		{
+			name: "missing spec.userConfig.configMap allowed when managed by Flux",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dex-app-unique",
+					Namespace: "giantswarm",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "0.0.0",
+						label.ManagedBy:          "flux",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "control-plane-catalog",
+					Name:      "dex-app",
+					Namespace: "giantswarm",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
+							Name:      "dex-app-user-values",
+							Namespace: "giantswarm",
+						},
+					},
+					Version: "1.2.2",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("control-plane-catalog", "default"),
+			},
+		},
+		{
 			name: "spec.userConfig.configMap no namespace specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
@@ -429,6 +460,37 @@ func Test_ValidateApp(t *testing.T) {
 				newTestCatalog("control-plane-catalog", "giantswarm"),
 			},
 			expectedErr: "validation error: secret `dex-app-user-secrets` in namespace `giantswarm` not found",
+		},
+		{
+			name: "missing spec.userConfig.secret allowed when managed by Flux",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dex-app-unique",
+					Namespace: "giantswarm",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "0.0.0",
+						label.ManagedBy:          "flux",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "control-plane-catalog",
+					Name:      "dex-app",
+					Namespace: "giantswarm",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						Secret: v1alpha1.AppSpecUserConfigSecret{
+							Name:      "dex-app-user-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+					Version: "1.2.2",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("control-plane-catalog", "giantswarm"),
+			},
 		},
 		{
 			name: "spec.userConfig.secret no namespace specified",

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -14,6 +14,7 @@ type Config struct {
 
 	ProjectName string
 	Provider    string
+	Conditional bool
 }
 
 type Validator struct {
@@ -23,6 +24,7 @@ type Validator struct {
 
 	projectName string
 	provider    string
+	conditional bool
 }
 
 func NewValidator(config Config) (*Validator, error) {
@@ -50,6 +52,7 @@ func NewValidator(config Config) (*Validator, error) {
 
 		projectName: config.ProjectName,
 		provider:    config.Provider,
+		conditional: config.Conditional,
 	}
 
 	return validator, nil

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -12,9 +12,9 @@ type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
-	ProjectName string
-	Provider    string
-	Conditional bool
+	ProjectName            string
+	Provider               string
+	ValidateResourcesExist bool
 }
 
 type Validator struct {
@@ -22,9 +22,9 @@ type Validator struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
-	projectName string
-	provider    string
-	conditional bool
+	projectName            string
+	provider               string
+	validateResourcesExist bool
 }
 
 func NewValidator(config Config) (*Validator, error) {
@@ -50,9 +50,9 @@ func NewValidator(config Config) (*Validator, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
-		projectName: config.ProjectName,
-		provider:    config.Provider,
-		conditional: config.Conditional,
+		projectName:            config.ProjectName,
+		provider:               config.Provider,
+		validateResourcesExist: config.ValidateResourcesExist,
 	}
 
 	return validator, nil


### PR DESCRIPTION
The code has been moved here from the `app-admission-controller`, see related PR [here](https://github.com/giantswarm/app-admission-controller/pull/217).

### Description

Important changes:

* `conditional` flag has been added to the `Validator`. I made the flag's name general and not related to Flux in particular in order to make it suitable for other use cases as well. At the moment it's used for conditional execution of `key.IsManagedByFlux` only,
* checking ConfigMaps and Secrets have been been moved to separate methods,
* `key.IsManagedByFlux` has been moved to the aforementioned methods and limited only to skipping the existence validation.