### PR TITLE
Validating labels for both cluster-managed and org-managed App CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for validating `giantswarm.io/cluster` label for org-namespaced App CRs.
+
 ## [6.5.1] - 2022-01-20
 
 ### Fixed

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -137,6 +137,10 @@ func IsDeleted(customResource v1alpha1.App) bool {
 	return customResource.DeletionTimestamp != nil
 }
 
+func IsInOrgNamespace(customResource v1alpha1.App) bool {
+	return strings.HasPrefix(customResource.ObjectMeta.Namespace, "org-")
+}
+
 // IsManagedByFlux returns true if the giantswarm.io/managed-by label is set to
 // flux and is being validated by app-admission-controller. When true we skip
 // validating configmap and secret names. This simplifies managing these
@@ -148,10 +152,6 @@ func IsManagedByFlux(customResource v1alpha1.App, projectName string) bool {
 	}
 
 	return customResource.Labels[label.ManagedBy] == "flux"
-}
-
-func IsManagedInOrg(customResource v1alpha1.App) bool {
-	return strings.HasPrefix(customResource.ObjectMeta.Namespace, "org-")
 }
 
 func KubeConfigContextName(customResource v1alpha1.App) string {

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -86,6 +86,14 @@ func ClusterID(customResource v1alpha1.App) string {
 	return customResource.GetLabels()[label.Cluster]
 }
 
+func ClusterLabel(customResource v1alpha1.App) string {
+	if val, ok := customResource.ObjectMeta.Labels[label.Cluster]; ok {
+		return val
+	}
+
+	return ""
+}
+
 func ClusterValuesConfigMapName(customResource v1alpha1.App) string {
 	return fmt.Sprintf("%s-cluster-values", customResource.GetNamespace())
 }
@@ -140,6 +148,10 @@ func IsManagedByFlux(customResource v1alpha1.App, projectName string) bool {
 	}
 
 	return customResource.Labels[label.ManagedBy] == "flux"
+}
+
+func IsManagedInOrg(customResource v1alpha1.App) bool {
+	return strings.HasPrefix(customResource.ObjectMeta.Namespace, "org-")
 }
 
 func KubeConfigContextName(customResource v1alpha1.App) string {

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -21,7 +21,6 @@ const (
 	nameNotFoundReasonTemplate        = "name is not specified for %s"
 	targetNamespaceNotAllowedTemplate = "target namespace %s is not allowed for in-cluster apps"
 	namespaceNotFoundReasonTemplate   = "namespace is not specified for %s %#q"
-	labelsConflictTemplate            = "label %#q is not allowed with the %#q label"
 	labelInvalidValueTemplate         = "label %#q has invalid value %#q"
 	labelNotFoundTemplate             = "label %#q not found"
 	resourceNotFoundTemplate          = "%s %#q in namespace %#q not found"
@@ -288,9 +287,6 @@ func (v *Validator) validateOrgLabels(ctx context.Context, cr v1alpha1.App) erro
 	// and there is no conflicting `app-operator.giantswarm.io/version` label.
 	if key.ClusterLabel(cr) == "" {
 		return microerror.Maskf(validationError, labelNotFoundTemplate, label.Cluster)
-	}
-	if key.VersionLabel(cr) != "" {
-		return microerror.Maskf(validationError, labelsConflictTemplate, label.AppOperatorVersion, label.Cluster)
 	}
 
 	return nil

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -261,14 +261,11 @@ func (v *Validator) validateLabels(ctx context.Context, cr v1alpha1.App) error {
 	// App CRs in cluster namespaces.
 	isManagedInOrg := !key.InCluster(cr) && key.IsInOrgNamespace(cr)
 
-	var validationMethod func(context.Context, v1alpha1.App) error
 	if isManagedInOrg {
-		validationMethod = v.validateOrgLabels
-	} else {
-		validationMethod = v.validateClusterLabels
+		return v.validateOrgLabels(ctx, cr)
 	}
 
-	return validationMethod(ctx, cr)
+	return v.validateClusterLabels(ctx, cr)
 }
 
 func (v *Validator) validateClusterLabels(ctx context.Context, cr v1alpha1.App) error {
@@ -283,8 +280,6 @@ func (v *Validator) validateClusterLabels(ctx context.Context, cr v1alpha1.App) 
 }
 
 func (v *Validator) validateOrgLabels(ctx context.Context, cr v1alpha1.App) error {
-	// For org-namespaced App CRs make sure the `giantswarm.io/cluster` is set,
-	// and there is no conflicting `app-operator.giantswarm.io/version` label.
 	if key.ClusterLabel(cr) == "" {
 		return microerror.Maskf(validationError, labelNotFoundTemplate, label.Cluster)
 	}

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -241,7 +241,6 @@ func Test_ValidateApp(t *testing.T) {
 			secrets: []*corev1.Secret{
 				newTestSecret("eggs2-kubeconfig", "org-eggs2"),
 			},
-			expectedErr: "label `app-operator.giantswarm.io/version` is not allowed with the `giantswarm.io/cluster` label",
 		},
 		{
 			name: "spec.catalog not found",

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -208,41 +208,6 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: label `giantswarm.io/cluster` not found",
 		},
 		{
-			name: "conflicting cluster and version labels",
-			obj: v1alpha1.App{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kiam",
-					Namespace: "org-eggs2",
-					Labels: map[string]string{
-						label.AppOperatorVersion: "2.6.0",
-						label.Cluster:            "eggs2",
-					},
-				},
-				Spec: v1alpha1.AppSpec{
-					Catalog:   "giantswarm",
-					Name:      "kiam",
-					Namespace: "kube-system",
-					KubeConfig: v1alpha1.AppSpecKubeConfig{
-						Context: v1alpha1.AppSpecKubeConfigContext{
-							Name: "eggs2-kubeconfig",
-						},
-						InCluster: false,
-						Secret: v1alpha1.AppSpecKubeConfigSecret{
-							Name:      "eggs2-kubeconfig",
-							Namespace: "org-eggs2",
-						},
-					},
-					Version: "1.4.0",
-				},
-			},
-			catalogs: []*v1alpha1.Catalog{
-				newTestCatalog("giantswarm", "default"),
-			},
-			secrets: []*corev1.Secret{
-				newTestSecret("eggs2-kubeconfig", "org-eggs2"),
-			},
-		},
-		{
 			name: "spec.catalog not found",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
App CRs living in the org namespace are going to have different logic applied in comparison to the App CRs living in the cluster namespace. Continuation of the https://github.com/giantswarm/giantswarm/issues/20443 issue and the https://github.com/giantswarm/kubectl-gs/pull/639 PR.