### PR TITLE
Revert "Ensure `application.giantswarm.io` CRDs from `apiextensions-application` (#246)"

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,6 +1,3 @@
-CVE-2022-29153 until=2022-07-01
-CVE-2022-29153 until=2022-07-01
-CVE-2022-21698 until=2022-07-01
-CVE-2021-20329 until=2022-07-01
-CVE-2021-38561 until=2022-07-01
-sonatype-2021-1401 until=2022-07-01
+# Affects all versions of archiver which is required by vault.
+# Taken from: https://github.com/giantswarm/opsctl/pull/1072/files#diff-bbe4a7fb12c43622bce7c6840c770e9995be614626a219942ca138403629cb69R1
+CVE-2019-10743 until=2021-10-17

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,6 @@
-# Affects all versions of archiver which is required by vault.
-# Taken from: https://github.com/giantswarm/opsctl/pull/1072/files#diff-bbe4a7fb12c43622bce7c6840c770e9995be614626a219942ca138403629cb69R1
-CVE-2019-10743 until=2021-10-17
+CVE-2022-29153 until=2022-07-01
+CVE-2022-29153 until=2022-07-01
+CVE-2022-21698 until=2022-07-01
+CVE-2021-20329 until=2022-07-01
+CVE-2021-38561 until=2022-07-01
+sonatype-2021-1401 until=2022-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `application.giantswarm.io` CRDs from `apiextensions-application` instead of `apiextensions`.
 
-## [6.10.0] - 2022-05-25
-
 ### Added
 
 - Add additional validation logic for the `chart-operator.giantswarm.io/app-namespace` annotation.


### PR DESCRIPTION
This reverts commit ef13285230e26210712712f05657cce2eee25cbe.

Apparently there is a "hack" script that pulls changes from other repos to apiextensions :rage1: 
