### PR TITLE
Changing order of conditions when getting cluster values for App CR

### DIFF
--- a/pkg/key/cluster.go
+++ b/pkg/key/cluster.go
@@ -12,13 +12,16 @@ const (
 )
 
 func ClusterConfigMapName(customResource v1alpha1.App) string {
+	// For the org-namespaced apps DO NOT distinguish two cases, namely
+	// the NGINX vs other apps, but instead use only one and the same
+	// `%s-cluster-values`
+	if IsInOrgNamespace(customResource) {
+		return fmt.Sprintf("%s-cluster-values", ClusterLabel(customResource))
+	}
+
 	// A separate config map is used for Nginx Ingress Controller.
 	if AppName(customResource) == nginxIngressControllerAppName {
 		return ingressControllerConfigMapName
-	}
-
-	if IsInOrgNamespace(customResource) {
-		return fmt.Sprintf("%s-cluster-values", ClusterLabel(customResource))
 	}
 
 	return fmt.Sprintf("%s-cluster-values", customResource.Namespace)

--- a/pkg/key/cluster_test.go
+++ b/pkg/key/cluster_test.go
@@ -1,0 +1,89 @@
+package key
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/giantswarm/k8smetadata/pkg/label"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_ClusterConfigMapName(t *testing.T) {
+	testCases := []struct {
+		name          string
+		obj           v1alpha1.App
+		expectedValue string
+	}{
+		{
+			name: "vintage non-NGINX",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hello-world",
+					Namespace: "demowc",
+				},
+				Spec: v1alpha1.AppSpec{
+					Name: "hello-world-app",
+				},
+			},
+			expectedValue: "demowc-cluster-values",
+		},
+		{
+			name: "vintage NGINX",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "demowc",
+				},
+				Spec: v1alpha1.AppSpec{
+					Name: nginxIngressControllerAppName,
+				},
+			},
+			expectedValue: ingressControllerConfigMapName,
+		},
+		{
+			name: "CAPx non-NGINX",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hello-world",
+					Namespace: "org-demoorg",
+					Labels: map[string]string{
+						label.Cluster: "demowc",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Name: "hello-world-app",
+				},
+			},
+			expectedValue: "demowc-cluster-values",
+		},
+		{
+			name: "CAPx NGINX",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hello-world",
+					Namespace: "org-demoorg",
+					Labels: map[string]string{
+						label.Cluster: "demowc",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Name: nginxIngressControllerAppName,
+				},
+			},
+			expectedValue: "demowc-cluster-values",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			t.Log(tc.name)
+
+			name := ClusterConfigMapName(tc.obj)
+
+			if name != tc.expectedValue {
+				t.Fatalf("AppConfigMapName %#q, want %#q", name, tc.expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23333

Apps for CAPx created in the `org-*` namespace cannot rely on the `ingress-controller-values` ConfigMap because nothing seems to create it for these apps, it seems such functionality is currently offered only to the vintage clusters via [cluster-operator](https://github.com/giantswarm/cluster-operator/blob/507d3528dd0d32e9134941632e4d56499c59638b/service/controller/resource/clusterconfigmap/desired.go#L131). This functionality does not seem to be implemented in the CAPx components, hence this slight change of order will allow org-namespaced NGINX apps to use the standard `%s-cluster-values` ConfigMap.