### PR TITLE
Extending checks allowing user ConfigMap and Secrets names without `Cluster_ID` prefix even when App CR name carries it.

### DIFF
--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8smetadata/pkg/label"
@@ -397,8 +398,34 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 		// managed by cluster-operator. So we don't need to restrict
 		// the name.
 		if key.CatalogName(cr) == defaultCatalogName && key.AppName(cr) != nginxIngressControllerAppName {
+			// This check is for `cluster-operator` only. For CAPI clusters, that does not rely on
+			// `cluster-operator`, the names could be any, but since it hasn't been conditioned earlier,
+			// making the whole function conditional now, when CAPI is well-established, may have some
+			// hard-to-predict consequences. Hence it is safer to let the function operate as usual,
+			// but in addition put some extra conditions like below.
+
+			// User ConfigMap name must, in general, match the '<App_CR_name>-user-values',
+			// with one exception below.
 			configMapName := fmt.Sprintf("%s-user-values", cr.Name)
-			if key.UserConfigMapName(cr) != configMapName {
+
+			nameMismatch := key.UserConfigMapName(cr) != configMapName
+
+			// As the result of misconfiguration for the legacy clusters, see
+			// https://github.com/giantswarm/cluster-operator/blob/1681bd32d19e4fda44993d7629eed227ff3cdc59/service/controller/resource/app/desired.go#L216,
+			// some default apps may carry names prefixed with the cluster ID, which are different from
+			// names of these apps as configured in the Release CR (without prefix). This is a problem, because
+			// Cluster Operator uses Release CR-originated names, to define user ConfigMap names. This in turn,
+			// fails the above condition, so another check is needed against name without the prefix.
+			if !key.IsInOrgNamespace(cr) && key.ClusterLabel(cr) != "" {
+				configMapName = strings.TrimPrefix(
+					configMapName,
+					fmt.Sprintf("%s-", key.ClusterLabel(cr)),
+				)
+
+				nameMismatch = nameMismatch && key.UserConfigMapName(cr) != configMapName
+			}
+
+			if nameMismatch {
 				return microerror.Maskf(validationError, "user configmap must be named %#q for app in default catalog", configMapName)
 			}
 		}
@@ -413,8 +440,34 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 
 	if key.UserSecretName(cr) != "" {
 		if key.CatalogName(cr) == defaultCatalogName {
+			// This check is for `cluster-operator` only. For CAPI clusters, that does not rely on
+			// `cluster-operator`, the names could be any, but since it hasn't been conditioned earlier,
+			// making the whole function conditional now, when CAPI is well-established, may have some
+			// hard-to-predict consequences. Hence it is safer to let the function operate as usual,
+			// but in addition put some extra conditions like below.
+
+			// User Secret name must, in general, match the '<App_CR_name>-user-secrets',
+			// with one exception below.
 			secretName := fmt.Sprintf("%s-user-secrets", cr.Name)
-			if key.UserSecretName(cr) != secretName {
+
+			nameMismatch := key.UserSecretName(cr) != secretName
+
+			// As the result of misconfiguration for the legacy clusters, see
+			// https://github.com/giantswarm/cluster-operator/blob/1681bd32d19e4fda44993d7629eed227ff3cdc59/service/controller/resource/app/desired.go#L216,
+			// some default apps may carry names prefixed with the cluster ID, which are different from
+			// names of these apps as configured in the Release CR (without prefix). This is a problem, because
+			// Cluster Operator uses Release CR-originated names, to define user Secret names. This in turn,
+			// fails the above condition, so another check is needed against name without the prefix.
+			if !key.IsInOrgNamespace(cr) && key.ClusterLabel(cr) != "" {
+				secretName = strings.TrimPrefix(
+					secretName,
+					fmt.Sprintf("%s-", key.ClusterLabel(cr)),
+				)
+
+				nameMismatch = nameMismatch && key.UserSecretName(cr) != secretName
+			}
+
+			if nameMismatch {
 				return microerror.Maskf(validationError, "user secret must be named %#q for app in default catalog", secretName)
 			}
 		}

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -410,9 +410,11 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 
 			nameMismatch := key.UserConfigMapName(cr) != configMapName
 
-			// As the result of misconfiguration for the legacy clusters, see
+			// The Cluster Operator may be told to create in-cluster app (aka bundle) for the WC,
+			// what requires special naming, like adding prefix or suffix, because otherwise a conflict
+			// may arise in within the MC, see:
 			// https://github.com/giantswarm/cluster-operator/blob/1681bd32d19e4fda44993d7629eed227ff3cdc59/service/controller/resource/app/desired.go#L216,
-			// some default apps may carry names prefixed with the cluster ID, which are different from
+			// Some default apps may hence carry names prefixed with the cluster ID, which are different from
 			// names of these apps as configured in the Release CR (without prefix). This is a problem, because
 			// Cluster Operator uses Release CR-originated names, to define user ConfigMap names. This in turn,
 			// fails the above condition, so another check is needed against name without the prefix.
@@ -452,9 +454,11 @@ func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) err
 
 			nameMismatch := key.UserSecretName(cr) != secretName
 
-			// As the result of misconfiguration for the legacy clusters, see
+			// The Cluster Operator may be told to create in-cluster app (aka bundle) for the WC,
+			// what requires special naming, like adding prefix or suffix, because otherwise a conflict
+			// may arise in within the MC, see:
 			// https://github.com/giantswarm/cluster-operator/blob/1681bd32d19e4fda44993d7629eed227ff3cdc59/service/controller/resource/app/desired.go#L216,
-			// some default apps may carry names prefixed with the cluster ID, which are different from
+			// Some default apps may hence carry names prefixed with the cluster ID, which are different from
 			// names of these apps as configured in the Release CR (without prefix). This is a problem, because
 			// Cluster Operator uses Release CR-originated names, to define user Secret names. This in turn,
 			// fails the above condition, so another check is needed against name without the prefix.

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -771,6 +771,47 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: user configmap must be named `kiam-user-values` for app in default catalog",
 		},
 		{
+			name: "spec.userConfig.configMap.name without the cluster prefix is allowed",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo01-observability-bundle",
+					Namespace: "demo01",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "0.0.0",
+						label.Cluster:            "demo01",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "default",
+					Name:      "observability-bundle",
+					Namespace: "demo01",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: false,
+						Secret: v1alpha1.AppSpecKubeConfigSecret{
+							Name:      "demo01-kubeconfig",
+							Namespace: "demo01",
+						},
+					},
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
+							Name:      "observability-bundle-user-values",
+							Namespace: "demo01",
+						},
+					},
+					Version: "1.2.2",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("default", "giantswarm"),
+			},
+			configMaps: []*corev1.ConfigMap{
+				newTestConfigMap("observability-bundle-user-values", "demo01"),
+			},
+			secrets: []*corev1.Secret{
+				newTestSecret("demo01-kubeconfig", "demo01"),
+			},
+		},
+		{
 			name: "spec.userConfig.secret.name incorrect for default catalog app",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
@@ -800,6 +841,45 @@ func Test_ValidateApp(t *testing.T) {
 				newTestCatalog("default", "giantswarm"),
 			},
 			expectedErr: "validation error: user secret must be named `kiam-user-secrets` for app in default catalog",
+		},
+		{
+			name: "spec.userConfig.secret.name without the cluster prefix is allowed",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo01-observability-bundle",
+					Namespace: "demo01",
+					Labels: map[string]string{
+						label.AppOperatorVersion: "0.0.0",
+						label.Cluster:            "demo01",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "default",
+					Name:      "observability-bundle",
+					Namespace: "demo01",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: false,
+						Secret: v1alpha1.AppSpecKubeConfigSecret{
+							Name:      "demo01-kubeconfig",
+							Namespace: "demo01",
+						},
+					},
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						Secret: v1alpha1.AppSpecUserConfigSecret{
+							Name:      "observability-bundle-user-secrets",
+							Namespace: "demo01",
+						},
+					},
+					Version: "1.2.2",
+				},
+			},
+			catalogs: []*v1alpha1.Catalog{
+				newTestCatalog("default", "giantswarm"),
+			},
+			secrets: []*corev1.Secret{
+				newTestSecret("demo01-kubeconfig", "demo01"),
+				newTestSecret("observability-bundle-user-secrets", "demo01"),
+			},
 		},
 		{
 			name: "metadata.name exceeds max length",


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25628