### PR TITLE
Introducing label selector

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -6,3 +6,4 @@ sonatype-2022-6522 until=2023-06-30
 # pkg:golang/github.com/hashicorp/consul/api@v1.1.0
 CVE-2022-29153 until=2023-06-30
 CVE-2021-41803 until=2023-06-30
+CVE-2022-41723 until=2023-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Account for ClusterSingleton and NamespaceSingleton for CAPI clusters.
+
 ## [6.15.2] - 2023-02-01
 
 ## [6.15.1] - 2022-11-17

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -1570,6 +1570,114 @@ func Test_ValidateMetadataConstraints(t *testing.T) {
 			},
 			expectedErr: "app `kiam` can only be installed once in cluster `eggs2`",
 		},
+		{
+			name: "case 7: namespace singleton constraint in org namespace (same cluster)",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam-zero",
+					Namespace: "org-test",
+					Labels: map[string]string{
+						label.Cluster: "eggs2",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					Version:   "1.4.0",
+				},
+			},
+			apps: []*v1alpha1.App{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kiam-good",
+						Namespace: "org-test",
+						Labels: map[string]string{
+							label.Cluster: "eggs2",
+						},
+					},
+					Spec: v1alpha1.AppSpec{
+						Catalog:   "giantswarm",
+						Name:      "kiam",
+						Namespace: "giantswarm",
+						Version:   "1.4.0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kiam-bad", // this is being installed to the same, `kube-system` namespace
+						Namespace: "org-test",
+						Labels: map[string]string{
+							label.Cluster: "eggs2",
+						},
+					},
+					Spec: v1alpha1.AppSpec{
+						Catalog:   "giantswarm",
+						Name:      "kiam",
+						Namespace: "kube-system",
+						Version:   "1.4.0",
+					},
+				},
+			},
+			catalogEntry: &v1alpha1.AppCatalogEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "giantswarm-kiam-1.4.0",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.AppCatalogEntrySpec{
+					Restrictions: &v1alpha1.AppCatalogEntrySpecRestrictions{
+						NamespaceSingleton: true,
+					},
+				},
+			},
+			expectedErr: "validation error: app `kiam` can only be installed only once in namespace `kube-system`",
+		},
+		{
+			name: "case 8: namespace singleton constraint in org namespace (different clusters)",
+			obj: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiam-zero",
+					Namespace: "org-test",
+					Labels: map[string]string{
+						label.Cluster: "eggs2",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kiam",
+					Namespace: "kube-system",
+					Version:   "1.4.0",
+				},
+			},
+			apps: []*v1alpha1.App{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kiam-good",
+						Namespace: "org-test",
+						Labels: map[string]string{
+							label.Cluster: "eggs3",
+						},
+					},
+					Spec: v1alpha1.AppSpec{
+						Catalog:   "giantswarm",
+						Name:      "kiam",
+						Namespace: "kube-system",
+						Version:   "1.4.0",
+					},
+				},
+			},
+			catalogEntry: &v1alpha1.AppCatalogEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "giantswarm-kiam-1.4.0",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.AppCatalogEntrySpec{
+					Restrictions: &v1alpha1.AppCatalogEntrySpecRestrictions{
+						NamespaceSingleton: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This PR re-works most of the changes introduced by Atlas in [this PR](https://github.com/giantswarm/app/pull/266). The solution introduced in there accounts for ORG namespace, but takes care only for cluster singletons, and does nothing for the namespace singletons. But more importantly, I believe, it does it the wrong way, I mean, all the apps are selected and then when being inspected we make sure we are not looking at the "wrong" ones, i.e., coming from the other clusters. While we should rather make sure we are not selecting the other clusters' apps, and then check them as usual without extra conditions imposed. So I restored the previous code and instead introduced label selector. 

I also re-worked the nested IF statements to make it more flat, it feels more readable this way, but if you like I can change it back.

Towards: https://github.com/giantswarm/giantswarm/issues/26140