### PR TITLE
Fixing ID part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Getting the cluster ID for all the clusters types.
+
 ## [6.15.3] - 2023-03-08
 
 ### Changed

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -383,8 +383,13 @@ func (v *Validator) validateMetadataConstraints(ctx context.Context, cr v1alpha1
 		}
 
 		if entry.Spec.Restrictions.ClusterSingleton {
+			clusterId := key.ClusterID(cr)
+
+			if clusterId == "" {
+				clusterId = cr.Namespace
+			}
 			return microerror.Maskf(validationError, "app %#q can only be installed once in cluster %#q",
-				cr.Spec.Name, key.ClusterID(cr))
+				cr.Spec.Name, clusterId)
 		}
 
 		if !entry.Spec.Restrictions.NamespaceSingleton {

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -1332,9 +1332,6 @@ func Test_ValidateMetadataConstraints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
 					Namespace: "eggs2",
-					Labels: map[string]string{
-						label.Cluster: "eggs2",
-					},
 				},
 				Spec: v1alpha1.AppSpec{
 					Catalog:   "giantswarm",
@@ -1348,9 +1345,6 @@ func Test_ValidateMetadataConstraints(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "another-kiam",
 						Namespace: "eggs2",
-						Labels: map[string]string{
-							label.Cluster: "eggs2",
-						},
 					},
 					Spec: v1alpha1.AppSpec{
 						Catalog:   "giantswarm",
@@ -1379,9 +1373,6 @@ func Test_ValidateMetadataConstraints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kiam",
 					Namespace: "eggs2",
-					Labels: map[string]string{
-						label.Cluster: "eggs2",
-					},
 				},
 				Spec: v1alpha1.AppSpec{
 					Catalog:   "giantswarm",
@@ -1395,9 +1386,6 @@ func Test_ValidateMetadataConstraints(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "another-kiam",
 						Namespace: "eggs2",
-						Labels: map[string]string{
-							label.Cluster: "eggs2",
-						},
 					},
 					Spec: v1alpha1.AppSpec{
 						Catalog:   "giantswarm",


### PR DESCRIPTION
I think people are not obliged to put the cluster label on the legacy clusters' apps. If so, then error message needs to be fixed because otherwise it may sometimes return an empty cluster id.