### PR TITLE
Fixing field selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix wrong field selector.
+
 ## [6.15.4] - 2023-03-09
 
 ### Fixed

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -358,7 +358,7 @@ func (v *Validator) validateMetadataConstraints(ctx context.Context, cr v1alpha1
 			}
 		}
 
-		fieldSelector, err := fields.ParseSelector(fmt.Sprintf("metadata.name!=%s", cr.Spec.Name))
+		fieldSelector, err := fields.ParseSelector(fmt.Sprintf("metadata.name!=%s", cr.Name))
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
I made a mistake when restoring older configuration and copied too much. Using `.spec.name` makes both AppOp and AppAdmissionCtrl to pick up app being submitted / processed.

Towards: https://giantswarm.app.opsgenie.com/alert/detail/f8b03c8b-22a3-4393-b445-466ac9269f57-1678442118383/details