### PR TITLE
App: Remove `nginx-ingress-controller-app` exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- App: Remove `nginx-ingress-controller-app` exceptions. ([#294](https://github.com/giantswarm/app/pull/294))
+
 ## [6.15.6] - 2023-03-30
 
 ### Added

--- a/pkg/key/cluster.go
+++ b/pkg/key/cluster.go
@@ -6,22 +6,9 @@ import (
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 )
 
-const (
-	ingressControllerConfigMapName = "ingress-controller-values"
-	nginxIngressControllerAppName  = "nginx-ingress-controller-app"
-)
-
 func ClusterConfigMapName(customResource v1alpha1.App) string {
-	// For the org-namespaced apps DO NOT distinguish two cases, namely
-	// the NGINX vs other apps, but instead use only one and the same
-	// `%s-cluster-values`
 	if IsInOrgNamespace(customResource) {
 		return fmt.Sprintf("%s-cluster-values", ClusterLabel(customResource))
-	}
-
-	// A separate config map is used for Nginx Ingress Controller.
-	if AppName(customResource) == nginxIngressControllerAppName {
-		return ingressControllerConfigMapName
 	}
 
 	return fmt.Sprintf("%s-cluster-values", customResource.Namespace)

--- a/pkg/key/cluster_test.go
+++ b/pkg/key/cluster_test.go
@@ -16,62 +16,33 @@ func Test_ClusterConfigMapName(t *testing.T) {
 		expectedValue string
 	}{
 		{
-			name: "vintage non-NGINX",
+			name: "Vintage",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "hello-world",
-					Namespace: "demowc",
+					Namespace: "demo",
 				},
 				Spec: v1alpha1.AppSpec{
-					Name: "hello-world-app",
+					Name: "hello-world",
 				},
 			},
-			expectedValue: "demowc-cluster-values",
+			expectedValue: "demo-cluster-values",
 		},
 		{
-			name: "vintage NGINX",
-			obj: v1alpha1.App{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "nginx",
-					Namespace: "demowc",
-				},
-				Spec: v1alpha1.AppSpec{
-					Name: nginxIngressControllerAppName,
-				},
-			},
-			expectedValue: ingressControllerConfigMapName,
-		},
-		{
-			name: "CAPx non-NGINX",
+			name: "CAPI",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "hello-world",
-					Namespace: "org-demoorg",
+					Namespace: "org-demo",
 					Labels: map[string]string{
-						label.Cluster: "demowc",
+						label.Cluster: "demo",
 					},
 				},
 				Spec: v1alpha1.AppSpec{
-					Name: "hello-world-app",
+					Name: "hello-world",
 				},
 			},
-			expectedValue: "demowc-cluster-values",
-		},
-		{
-			name: "CAPx NGINX",
-			obj: v1alpha1.App{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "hello-world",
-					Namespace: "org-demoorg",
-					Labels: map[string]string{
-						label.Cluster: "demowc",
-					},
-				},
-				Spec: v1alpha1.AppSpec{
-					Name: nginxIngressControllerAppName,
-				},
-			},
-			expectedValue: "demowc-cluster-values",
+			expectedValue: "demo-cluster-values",
 		},
 	}
 

--- a/pkg/validation/app.go
+++ b/pkg/validation/app.go
@@ -29,8 +29,7 @@ const (
 	labelInClusterAppTemplate         = "label %#q must be set to `0.0.0` for in-cluster app"
 	resourceNotFoundTemplate          = "%s %#q in namespace %#q not found"
 
-	defaultCatalogName            = "default"
-	nginxIngressControllerAppName = "nginx-ingress-controller-app"
+	defaultCatalogName = "default"
 
 	// nameMaxLength is 53 characters as this is the maximum allowed for Helm
 	// release names.
@@ -423,10 +422,7 @@ func (v *Validator) validateNamespaceUpdate(ctx context.Context, app, currentApp
 
 func (v *Validator) validateUserConfig(ctx context.Context, cr v1alpha1.App) error {
 	if key.UserConfigMapName(cr) != "" {
-		// NGINX Ingress Controller is no longer a pre-installed app
-		// managed by cluster-operator. So we don't need to restrict
-		// the name.
-		if key.CatalogName(cr) == defaultCatalogName && key.AppName(cr) != nginxIngressControllerAppName {
+		if key.CatalogName(cr) == defaultCatalogName {
 			// This check is for `cluster-operator` only. For CAPI clusters, that does not rely on
 			// `cluster-operator`, the names could be any, but since it hasn't been conditioned earlier,
 			// making the whole function conditional now, when CAPI is well-established, may have some

--- a/pkg/validation/app_test.go
+++ b/pkg/validation/app_test.go
@@ -932,39 +932,6 @@ func Test_ValidateApp(t *testing.T) {
 			expectedErr: "validation error: label `app-operator.giantswarm.io/version` has invalid value `1.0.0`",
 		},
 		{
-			name: "nginx user values configmap name is not restricted",
-			obj: v1alpha1.App{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kiam",
-					Namespace: "giantswarm",
-					Labels: map[string]string{
-						label.AppOperatorVersion: "0.0.0",
-					},
-				},
-				Spec: v1alpha1.AppSpec{
-					Catalog:   "default",
-					Name:      "nginx-ingress-controller-app",
-					Namespace: "kube-system",
-					KubeConfig: v1alpha1.AppSpecKubeConfig{
-						InCluster: true,
-					},
-					UserConfig: v1alpha1.AppSpecUserConfig{
-						ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
-							Name:      "nginx-ingress-user-values",
-							Namespace: "eggs2",
-						},
-					},
-					Version: "1.4.0",
-				},
-			},
-			catalogs: []*v1alpha1.Catalog{
-				newTestCatalog("default", "default"),
-			},
-			configMaps: []*corev1.ConfigMap{
-				newTestConfigMap("nginx-ingress-user-values", "eggs2"),
-			},
-		},
-		{
 			name: "spec.kubeConfig.secret no name specified",
 			obj: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Those exceptions can safely be removed since neither the `nginx-ingress-controller-app` nor its successor `ingress-nginx` do rely on the `ingress-controller-values` `ConfigMap` anymore. The included `configmap.proxy-protocol` key is automatically determined for a long time now and versions still requiring it are using an image which is not supported with Kubernetes versions included in current `cluster-operator` versions.

Like: New `cluster-operator` versions including this change come with recent Kubernetes versions. Old `nginx-ingress-controller-app` versions still relying on the `ingress-controller-values` `ConfigMap` might not be supported with those Kubernetes versions.