### PR TITLE
Adding SecretExtraConfig and ConfigMapExtraConfig

### DIFF
--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -207,7 +207,7 @@ func SecretExtraConfigs(customResource v1alpha1.App) []v1alpha1.AppExtraConfig {
 
 	for _, v := range customResource.Spec.ExtraConfigs {
 		if v.Kind == "secret" {
-			extraConfigs = append(extraConfigs,v)
+			extraConfigs = append(extraConfigs, v)
 		}
 	}
 

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -109,19 +109,7 @@ func ConfigMapExtraConfigs(customResource v1alpha1.App) []v1alpha1.AppExtraConfi
 	extraConfigs := []v1alpha1.AppExtraConfig{}
 
 	for _, v := range customResource.Spec.ExtraConfigs {
-		// According to the Kubernetes docs,
-		// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting,
-		// the `v.Kind == ""` is not needed, for even if an extra config item was originally
-		// provided with the empty kind, it should get stored in the ETCD with a default
-		// value of the `configMap`, according to our configuration, thanks to the defaulting.
-		//
-		// We configure default value here:
-		// https://github.com/giantswarm/apiextensions-application/blob/main/api/v1alpha1/app_types.go#L142
-		//
-		// I am adding this condition anyway, for we have already used similar ones in different places,
-		// which makes it unclear to me whether we have discovered Kubernetes does not perform defaulting
-		// in certain scenarios, or we added this purely as extra-precaution messure.
-		if v.Kind == "configMap" || v.Kind == "" {
+		if v.Kind != "secret" {
 			extraConfigs = append(extraConfigs, v)
 		}
 	}

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -109,12 +109,18 @@ func ConfigMapExtraConfigs(customResource v1alpha1.App) []v1alpha1.AppExtraConfi
 	extraConfigs := []v1alpha1.AppExtraConfig{}
 
 	for _, v := range customResource.Spec.ExtraConfigs {
-		// According to the
-		// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting
-		// the `v.Kind == ""` is not really needed, for even if object was
-		// originally provided with empty kind, it should get stored in the ETCD
-		// with a default value. Adding this condition anyway, for we have already
-		// used similar ones in different places.
+		// According to the Kubernetes docs,
+		// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting,
+		// the `v.Kind == ""` is not needed, for even if an extra config item was originally
+		// provided with the empty kind, it should get stored in the ETCD with a default
+		// value of the `configMap`, according to our configuration, thanks to the defaulting.
+		//
+		// We configure default value here:
+		// https://github.com/giantswarm/apiextensions-application/blob/main/api/v1alpha1/app_types.go#L142
+		//
+		// I am adding this condition anyway, for we have already used similar ones in different places,
+		// which makes it unclear to me whether we have discovered Kubernetes does not perform defaulting
+		// in certain scenarios, or we added this purely as extra-precaution messure.
 		if v.Kind == "configMap" || v.Kind == "" {
 			extraConfigs = append(extraConfigs, v)
 		}

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -109,7 +109,13 @@ func ConfigMapExtraConfigs(customResource v1alpha1.App) []v1alpha1.AppExtraConfi
 	extraConfigs := []v1alpha1.AppExtraConfig{}
 
 	for _, v := range customResource.Spec.ExtraConfigs {
-		if v.Kind == "configMap" {
+		// According to the
+		// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting
+		// the `v.Kind == ""` is not really needed, for even if object was
+		// originally provided with empty kind, it should get stored in the ETCD
+		// with a default value. Adding this condition anyway, for we have already
+		// used similar ones in different places.
+		if v.Kind == "configMap" || v.Kind == "" {
 			extraConfigs = append(extraConfigs, v)
 		}
 	}

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -202,6 +202,18 @@ func RollbackTimeout(customResource v1alpha1.App) *metav1.Duration {
 	return customResource.Spec.Rollback.Timeout
 }
 
+func SecretExtraConfigs(customResource v1alpha1.App) []v1alpha1.AppExtraConfig {
+	extraConfigs := []v1alpha1.AppExtraConfig{}
+
+	for _, v := range customResource.Spec.ExtraConfigs {
+		if v.Kind == "secret" {
+			extraConfigs = append(extraConfigs,v)
+		}
+	}
+
+	return extraConfigs
+}
+
 func ToApp(v interface{}) (v1alpha1.App, error) {
 	customResource, ok := v.(*v1alpha1.App)
 	if !ok {

--- a/pkg/key/app.go
+++ b/pkg/key/app.go
@@ -105,6 +105,18 @@ func ClusterValuesConfigMapName(customResource v1alpha1.App) string {
 	return fmt.Sprintf("%s-cluster-values", customResource.GetNamespace())
 }
 
+func ConfigMapExtraConfigs(customResource v1alpha1.App) []v1alpha1.AppExtraConfig {
+	extraConfigs := []v1alpha1.AppExtraConfig{}
+
+	for _, v := range customResource.Spec.ExtraConfigs {
+		if v.Kind == "configMap" {
+			extraConfigs = append(extraConfigs, v)
+		}
+	}
+
+	return extraConfigs
+}
+
 func CordonReason(customResource v1alpha1.App) string {
 	return customResource.GetAnnotations()[annotation.ChartOperatorCordonReason]
 }

--- a/pkg/key/app_test.go
+++ b/pkg/key/app_test.go
@@ -416,12 +416,12 @@ func Test_SecretExtraConfigs(t *testing.T) {
 	testCases := []struct {
 		name          string
 		obj           v1alpha1.App
-		expectedList []v1alpha1.AppExtraConfig
+		expectedList  []v1alpha1.AppExtraConfig
 	}{
 		{
 			name:          "case 0: no extra Secrets",
 			obj:           v1alpha1.App{},
-			expectedList: []v1alpha1.AppExtraConfig{},
+			expectedList:  []v1alpha1.AppExtraConfig{},
 		},
 		{
 			name: "case 1: extra configs has Secrets and ConfigMaps",
@@ -429,13 +429,13 @@ func Test_SecretExtraConfigs(t *testing.T) {
 				Spec: v1alpha1.AppSpec{
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						v1alpha1.AppExtraConfig{
-							Kind: "configMap",
-							Name: "test",
+							Kind:      "configMap",
+							Name:      "test",
 							Namespace: "test",
 						},
 						v1alpha1.AppExtraConfig{
-							Kind: "secret",
-							Name: "test",
+							Kind:      "secret",
+							Name:      "test",
 							Namespace: "test",
 						},
 					},
@@ -443,8 +443,8 @@ func Test_SecretExtraConfigs(t *testing.T) {
 			},
 			expectedList: []v1alpha1.AppExtraConfig{
 				v1alpha1.AppExtraConfig{
-					Kind: "secret",
-					Name: "test",
+					Kind:      "secret",
+					Name:      "test",
 					Namespace: "test",
 				},
 			},
@@ -455,8 +455,8 @@ func Test_SecretExtraConfigs(t *testing.T) {
 				Spec: v1alpha1.AppSpec{
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						v1alpha1.AppExtraConfig{
-							Kind: "secret",
-							Name: "test",
+							Kind:      "secret",
+							Name:      "test",
 							Namespace: "test",
 						},
 					},
@@ -464,8 +464,8 @@ func Test_SecretExtraConfigs(t *testing.T) {
 			},
 			expectedList: []v1alpha1.AppExtraConfig{
 				v1alpha1.AppExtraConfig{
-					Kind: "secret",
-					Name: "test",
+					Kind:      "secret",
+					Name:      "test",
 					Namespace: "test",
 				},
 			},
@@ -476,8 +476,8 @@ func Test_SecretExtraConfigs(t *testing.T) {
 				Spec: v1alpha1.AppSpec{
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						v1alpha1.AppExtraConfig{
-							Kind: "configMap",
-							Name: "test",
+							Kind:      "configMap",
+							Name:      "test",
 							Namespace: "test",
 						},
 					},
@@ -493,7 +493,7 @@ func Test_SecretExtraConfigs(t *testing.T) {
 
 			extraConfigs := SecretExtraConfigs(tc.obj)
 
-			if !reflect.DeepEqual(extraConfigs,tc.expectedList) {
+			if !reflect.DeepEqual(extraConfigs, tc.expectedList) {
 				t.Fatalf("List equals == %#v, want %#v", extraConfigs, tc.expectedList)
 			}
 		})

--- a/pkg/key/app_test.go
+++ b/pkg/key/app_test.go
@@ -224,6 +224,94 @@ func Test_CatalogName(t *testing.T) {
 	}
 }
 
+func Test_ConfigMapExtraConfigs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		obj          v1alpha1.App
+		expectedList []v1alpha1.AppExtraConfig
+	}{
+		{
+			name:         "case 0: no extra configs at all",
+			obj:          v1alpha1.App{},
+			expectedList: []v1alpha1.AppExtraConfig{},
+		},
+		{
+			name: "case 1: extra configs has Secrets and ConfigMaps",
+			obj: v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						v1alpha1.AppExtraConfig{
+							Kind:      "configMap",
+							Name:      "test",
+							Namespace: "test",
+						},
+						v1alpha1.AppExtraConfig{
+							Kind:      "secret",
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedList: []v1alpha1.AppExtraConfig{
+				v1alpha1.AppExtraConfig{
+					Kind:      "configMap",
+					Name:      "test",
+					Namespace: "test",
+				},
+			},
+		},
+		{
+			name: "case 2: extra configs has Secrets only",
+			obj: v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						v1alpha1.AppExtraConfig{
+							Kind:      "secret",
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedList: []v1alpha1.AppExtraConfig{},
+		},
+		{
+			name: "case 3: extra configs has ConfigMaps only",
+			obj: v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						v1alpha1.AppExtraConfig{
+							Kind:      "configMap",
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedList: []v1alpha1.AppExtraConfig{
+				v1alpha1.AppExtraConfig{
+					Kind:      "configMap",
+					Name:      "test",
+					Namespace: "test",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			extraConfigs := ConfigMapExtraConfigs(tc.obj)
+
+			if !reflect.DeepEqual(extraConfigs, tc.expectedList) {
+				t.Fatalf("List equals == %#v, want %#v", extraConfigs, tc.expectedList)
+			}
+		})
+	}
+}
+
 func Test_CordonReason(t *testing.T) {
 	expectedCordonReason := "manual upgrade"
 

--- a/pkg/key/app_test.go
+++ b/pkg/key/app_test.go
@@ -414,14 +414,14 @@ func Test_Namespace(t *testing.T) {
 
 func Test_SecretExtraConfigs(t *testing.T) {
 	testCases := []struct {
-		name          string
-		obj           v1alpha1.App
-		expectedList  []v1alpha1.AppExtraConfig
+		name         string
+		obj          v1alpha1.App
+		expectedList []v1alpha1.AppExtraConfig
 	}{
 		{
-			name:          "case 0: no extra Secrets",
-			obj:           v1alpha1.App{},
-			expectedList:  []v1alpha1.AppExtraConfig{},
+			name:         "case 0: no extra Secrets",
+			obj:          v1alpha1.App{},
+			expectedList: []v1alpha1.AppExtraConfig{},
 		},
 		{
 			name: "case 1: extra configs has Secrets and ConfigMaps",

--- a/pkg/key/app_test.go
+++ b/pkg/key/app_test.go
@@ -412,6 +412,94 @@ func Test_Namespace(t *testing.T) {
 	}
 }
 
+func Test_SecretExtraConfigs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		obj           v1alpha1.App
+		expectedList []v1alpha1.AppExtraConfig
+	}{
+		{
+			name:          "case 0: no extra Secrets",
+			obj:           v1alpha1.App{},
+			expectedList: []v1alpha1.AppExtraConfig{},
+		},
+		{
+			name: "case 1: extra configs has Secrets and ConfigMaps",
+			obj: v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						v1alpha1.AppExtraConfig{
+							Kind: "configMap",
+							Name: "test",
+							Namespace: "test",
+						},
+						v1alpha1.AppExtraConfig{
+							Kind: "secret",
+							Name: "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedList: []v1alpha1.AppExtraConfig{
+				v1alpha1.AppExtraConfig{
+					Kind: "secret",
+					Name: "test",
+					Namespace: "test",
+				},
+			},
+		},
+		{
+			name: "case 2: extra configs has Secrets only",
+			obj: v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						v1alpha1.AppExtraConfig{
+							Kind: "secret",
+							Name: "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedList: []v1alpha1.AppExtraConfig{
+				v1alpha1.AppExtraConfig{
+					Kind: "secret",
+					Name: "test",
+					Namespace: "test",
+				},
+			},
+		},
+		{
+			name: "case 3: extra configs has ConfigMaps only",
+			obj: v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						v1alpha1.AppExtraConfig{
+							Kind: "configMap",
+							Name: "test",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedList: []v1alpha1.AppExtraConfig{},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			extraConfigs := SecretExtraConfigs(tc.obj)
+
+			if !reflect.DeepEqual(extraConfigs,tc.expectedList) {
+				t.Fatalf("List equals == %#v, want %#v", extraConfigs, tc.expectedList)
+			}
+		})
+	}
+}
+
 func Test_ToApp(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/pkg/values/configmap.go
+++ b/pkg/values/configmap.go
@@ -25,7 +25,7 @@ func (v *Values) MergeConfigMapData(ctx context.Context, app v1alpha1.App, catal
 	catalogConfigMapName := key.CatalogConfigMapName(catalog)
 	userConfigMapName := key.UserConfigMapName(app)
 
-	extraConfigs := key.ExtraConfigs(app)
+	extraConfigs := key.ConfigMapExtraConfigs(app)
 
 	if appConfigMapName == "" && catalogConfigMapName == "" && userConfigMapName == "" && len(extraConfigs) == 0 {
 		// Return early as there is no config.

--- a/pkg/values/configmap_test.go
+++ b/pkg/values/configmap_test.go
@@ -251,6 +251,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 					Namespace: "giantswarm",
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						{
+							Kind:      "configMap",
 							Name:      "pre-cluster-overrides",
 							Namespace: "giantswarm",
 						},
@@ -290,11 +291,13 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						{
+							Kind:      "configMap",
 							Name:      "post-cluster-overrides",
 							Namespace: "giantswarm",
 							Priority:  v1alpha1.ConfigPriorityCluster + 1,
 						},
 						{
+							Kind:      "configMap",
 							Name:      "pre-cluster-overrides",
 							Namespace: "giantswarm",
 						},
@@ -349,20 +352,24 @@ func Test_MergeConfigMapData(t *testing.T) {
 					},
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						{
+							Kind:      "configMap",
 							Name:      "post-user-overrides-2",
 							Namespace: "giantswarm",
 							Priority:  v1alpha1.ConfigPriorityMaximum,
 						},
 						{
+							Kind:      "configMap",
 							Name:      "post-cluster-overrides",
 							Namespace: "giantswarm",
 							Priority:  v1alpha1.ConfigPriorityCluster + 1,
 						},
 						{
+							Kind:      "configMap",
 							Name:      "pre-cluster-overrides",
 							Namespace: "giantswarm",
 						},
 						{
+							Kind:      "configMap",
 							Name:      "post-user-overrides-1",
 							Namespace: "giantswarm",
 							Priority:  v1alpha1.ConfigPriorityUser + 1,
@@ -419,6 +426,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 					Namespace: "giantswarm",
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						{
+							Kind:      "configMap",
 							Name:      "post-user-overrides",
 							Namespace: "giantswarm",
 							Priority:  v1alpha1.ConfigPriorityMaximum,
@@ -448,6 +456,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 					Namespace: "giantswarm",
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						{
+							Kind:      "configMap",
 							Name:      "pre-cluster-overrides",
 							Namespace: "giantswarm",
 						},
@@ -479,10 +488,12 @@ func Test_MergeConfigMapData(t *testing.T) {
 					Namespace: "giantswarm",
 					ExtraConfigs: []v1alpha1.AppExtraConfig{
 						{
+							Kind:      "configMap",
 							Name:      "pre-cluster-overrides-1",
 							Namespace: "giantswarm",
 						},
 						{
+							Kind:      "configMap",
 							Name:      "pre-cluster-overrides-2",
 							Namespace: "giantswarm",
 						},
@@ -506,6 +517,33 @@ func Test_MergeConfigMapData(t *testing.T) {
 				"foo":   "baz",
 				"hello": "world",
 			},
+		},
+		{
+			name: "case multi layer 8: no secret configs",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "test-catalog",
+					Name:      "test-app",
+					Namespace: "giantswarm",
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						{
+							Kind:      "secret",
+							Name:      "test-secret",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			catalog: v1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+			},
+			expectedData: nil,
 		},
 	}
 
@@ -541,7 +579,7 @@ func Test_MergeConfigMapData(t *testing.T) {
 				t.Fatalf("expected nil map got %#v", result)
 			}
 			if result == nil && tc.expectedData != nil {
-				t.Fatal("expected non-nil gmap got nil")
+				t.Fatal("expected non-nil map got nil")
 			}
 
 			if tc.expectedData != nil {

--- a/pkg/values/secret.go
+++ b/pkg/values/secret.go
@@ -20,7 +20,7 @@ func (v *Values) MergeSecretData(ctx context.Context, app v1alpha1.App, catalog 
 	catalogSecretName := key.CatalogSecretName(catalog)
 	userSecretName := key.UserSecretName(app)
 
-	extraConfigs := key.ExtraConfigs(app)
+	extraConfigs := key.SecretExtraConfigs(app)
 
 	if appSecretName == "" && catalogSecretName == "" && userSecretName == "" && len(extraConfigs) == 0 {
 		// Return early as there is no secret.

--- a/pkg/values/secret_test.go
+++ b/pkg/values/secret_test.go
@@ -19,6 +19,7 @@ func Test_MergeSecretData(t *testing.T) {
 		name         string
 		app          v1alpha1.App
 		catalog      v1alpha1.Catalog
+		configMaps   []*corev1.ConfigMap
 		secrets      []*corev1.Secret
 		expectedData map[string]interface{}
 		errorMatcher func(error) bool
@@ -548,6 +549,33 @@ func Test_MergeSecretData(t *testing.T) {
 				"foo":   "baz",
 				"hello": "world",
 			},
+		},
+		{
+			name: "case multi layer 8: no extra secrets",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "test-catalog",
+					Name:      "test-app",
+					Namespace: "giantswarm",
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						{
+							Kind:      "configMap",
+							Name:      "test-config-map",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			catalog: v1alpha1.Catalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+			},
+			expectedData: nil, // we do not want the map[string]interface{}{} here
 		},
 	}
 	ctx := context.Background()

--- a/pkg/values/secret_test.go
+++ b/pkg/values/secret_test.go
@@ -19,7 +19,6 @@ func Test_MergeSecretData(t *testing.T) {
 		name         string
 		app          v1alpha1.App
 		catalog      v1alpha1.Catalog
-		configMaps   []*corev1.ConfigMap
 		secrets      []*corev1.Secret
 		expectedData map[string]interface{}
 		errorMatcher func(error) bool


### PR DESCRIPTION
Towards: https://github.com/giantswarm/adidas/issues/1326

This PR introduces two functions in the `pkg/key` package, the `ConfigMapExtraConfigs` and the `SecretExtraConfigs`, for getting ConfigMaps and Secrets from the extra configs list respectively, and updates the `pkg/values` package to use them.